### PR TITLE
added testing for spot parsers. 

### DIFF
--- a/parser/dev_notebooks/dev_test_spot_track.ipynb
+++ b/parser/dev_notebooks/dev_test_spot_track.ipynb
@@ -1,0 +1,4247 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "id": "d2a66c29",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import sys\n",
+    "\n",
+    "sys.path.append(\"..\")\n",
+    "import os\n",
+    "import time\n",
+    "import glob\n",
+    "import numpy as np\n",
+    "import pandas as pd\n",
+    "from typing import List, Dict, Union, Tuple\n",
+    "from utils.data import load_yaml\n",
+    "from imaris.imaris import ImarisDataObject\n",
+    "from parsers.spot_track_parser import SpotTrackParserDistributed\n",
+    "from parsers.spot_track_object_parser import SpotTrackObjectParserDistributed\n",
+    "from tqdm.notebook import tqdm\n",
+    "\n",
+    "import csv"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "b691f834",
+   "metadata": {},
+   "source": [
+    "Get Stats From Parser"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "id": "f7aca90d",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# test ims file path\n",
+    "test_ims_file = \"../../data/imaris_parser_test_files/Spots/KO Sec1 Roi1 3x3 80min.ims\""
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "id": "2303f43a",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "parser = SpotTrackParserDistributed(test_ims_file)\n",
+    "out = parser.inspect(1)\n",
+    "parser_df = out[\"final_df\"]\n",
+    "parser_stat_names = list(parser_df.columns)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "bd79d084",
+   "metadata": {},
+   "source": [
+    "Get Stats From Test Files"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "id": "5c002c29",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# track stats folder\n",
+    "track_stats_dir = \"../../data/imaris_parser_test_files/Spots/KO Sec1 Roi1 3x3 80min-testtracks_Statistics\"\n",
+    "\n",
+    "# object stats folder\n",
+    "# object_stats_dir = (\n",
+    "#     \"../../data/imaris_parser_test_files/Spots/KO Sec1 Roi1 3x3 80min_Statistics\"\n",
+    "# )"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "id": "7369d0c4",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "track_stats_files = glob.glob(os.path.join(track_stats_dir, \"*.csv\"))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "id": "eaa17285",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Track Volume Mean \n",
+      "\n"
+     ]
+    },
+    {
+     "data": {
+      "application/vnd.microsoft.datawrangler.viewer.v0+json": {
+       "columns": [
+        {
+         "name": "index",
+         "rawType": "int64",
+         "type": "integer"
+        },
+        {
+         "name": "Track Volume Mean",
+         "rawType": "object",
+         "type": "string"
+        },
+        {
+         "name": "Unit",
+         "rawType": "object",
+         "type": "string"
+        },
+        {
+         "name": "Category",
+         "rawType": "object",
+         "type": "string"
+        },
+        {
+         "name": "ID",
+         "rawType": "object",
+         "type": "string"
+        },
+        {
+         "name": "",
+         "rawType": "object",
+         "type": "string"
+        }
+       ],
+       "ref": "bb3722f6-a0b6-4333-bce8-3a695eae86dc",
+       "rows": [
+        [
+         "0",
+         "648.609",
+         "µm^3",
+         "Track",
+         "1000000039",
+         ""
+        ],
+        [
+         "1",
+         "648.609",
+         "µm^3",
+         "Track",
+         "1000000042",
+         ""
+        ],
+        [
+         "2",
+         "648.609",
+         "µm^3",
+         "Track",
+         "1000000060",
+         ""
+        ],
+        [
+         "3",
+         "648.609",
+         "µm^3",
+         "Track",
+         "1000000065",
+         ""
+        ],
+        [
+         "4",
+         "648.609",
+         "µm^3",
+         "Track",
+         "1000000073",
+         ""
+        ],
+        [
+         "5",
+         "648.609",
+         "µm^3",
+         "Track",
+         "1000000083",
+         ""
+        ],
+        [
+         "6",
+         "648.609",
+         "µm^3",
+         "Track",
+         "1000000085",
+         ""
+        ],
+        [
+         "7",
+         "648.609",
+         "µm^3",
+         "Track",
+         "1000000091",
+         ""
+        ],
+        [
+         "8",
+         "648.609",
+         "µm^3",
+         "Track",
+         "1000000110",
+         ""
+        ],
+        [
+         "9",
+         "648.609",
+         "µm^3",
+         "Track",
+         "1000000114",
+         ""
+        ],
+        [
+         "10",
+         "648.609",
+         "µm^3",
+         "Track",
+         "1000000120",
+         ""
+        ],
+        [
+         "11",
+         "648.609",
+         "µm^3",
+         "Track",
+         "1000000135",
+         ""
+        ],
+        [
+         "12",
+         "648.609",
+         "µm^3",
+         "Track",
+         "1000000151",
+         ""
+        ],
+        [
+         "13",
+         "648.609",
+         "µm^3",
+         "Track",
+         "1000000161",
+         ""
+        ],
+        [
+         "14",
+         "648.609",
+         "µm^3",
+         "Track",
+         "1000000170",
+         ""
+        ],
+        [
+         "15",
+         "648.609",
+         "µm^3",
+         "Track",
+         "1000000179",
+         ""
+        ],
+        [
+         "16",
+         "648.609",
+         "µm^3",
+         "Track",
+         "1000000188",
+         ""
+        ],
+        [
+         "17",
+         "648.609",
+         "µm^3",
+         "Track",
+         "1000000189",
+         ""
+        ],
+        [
+         "18",
+         "648.609",
+         "µm^3",
+         "Track",
+         "1000000190",
+         ""
+        ],
+        [
+         "19",
+         "648.609",
+         "µm^3",
+         "Track",
+         "1000000193",
+         ""
+        ],
+        [
+         "20",
+         "648.609",
+         "µm^3",
+         "Track",
+         "1000000195",
+         ""
+        ],
+        [
+         "21",
+         "648.609",
+         "µm^3",
+         "Track",
+         "1000000199",
+         ""
+        ],
+        [
+         "22",
+         "648.609",
+         "µm^3",
+         "Track",
+         "1000000200",
+         ""
+        ],
+        [
+         "23",
+         "648.609",
+         "µm^3",
+         "Track",
+         "1000000239",
+         ""
+        ],
+        [
+         "24",
+         "648.609",
+         "µm^3",
+         "Track",
+         "1000000265",
+         ""
+        ],
+        [
+         "25",
+         "648.609",
+         "µm^3",
+         "Track",
+         "1000000317",
+         ""
+        ],
+        [
+         "26",
+         "648.609",
+         "µm^3",
+         "Track",
+         "1000000391",
+         ""
+        ],
+        [
+         "27",
+         "648.609",
+         "µm^3",
+         "Track",
+         "1000000399",
+         ""
+        ],
+        [
+         "28",
+         "648.609",
+         "µm^3",
+         "Track",
+         "1000000410",
+         ""
+        ],
+        [
+         "29",
+         "648.609",
+         "µm^3",
+         "Track",
+         "1000000496",
+         ""
+        ],
+        [
+         "30",
+         "648.609",
+         "µm^3",
+         "Track",
+         "1000000557",
+         ""
+        ],
+        [
+         "31",
+         "648.609",
+         "µm^3",
+         "Track",
+         "1000000562",
+         ""
+        ],
+        [
+         "32",
+         "648.609",
+         "µm^3",
+         "Track",
+         "1000000569",
+         ""
+        ],
+        [
+         "33",
+         "648.609",
+         "µm^3",
+         "Track",
+         "1000000570",
+         ""
+        ],
+        [
+         "34",
+         "648.609",
+         "µm^3",
+         "Track",
+         "1000000573",
+         ""
+        ],
+        [
+         "35",
+         "648.609",
+         "µm^3",
+         "Track",
+         "1000000581",
+         ""
+        ],
+        [
+         "36",
+         "648.609",
+         "µm^3",
+         "Track",
+         "1000000587",
+         ""
+        ],
+        [
+         "37",
+         "648.609",
+         "µm^3",
+         "Track",
+         "1000000588",
+         ""
+        ],
+        [
+         "38",
+         "648.609",
+         "µm^3",
+         "Track",
+         "1000000590",
+         ""
+        ],
+        [
+         "39",
+         "648.609",
+         "µm^3",
+         "Track",
+         "1000000611",
+         ""
+        ],
+        [
+         "40",
+         "648.609",
+         "µm^3",
+         "Track",
+         "1000000620",
+         ""
+        ],
+        [
+         "41",
+         "648.609",
+         "µm^3",
+         "Track",
+         "1000000745",
+         ""
+        ],
+        [
+         "42",
+         "648.609",
+         "µm^3",
+         "Track",
+         "1000000751",
+         ""
+        ],
+        [
+         "43",
+         "648.609",
+         "µm^3",
+         "Track",
+         "1000000759",
+         ""
+        ],
+        [
+         "44",
+         "648.609",
+         "µm^3",
+         "Track",
+         "1000000766",
+         ""
+        ],
+        [
+         "45",
+         "648.609",
+         "µm^3",
+         "Track",
+         "1000000947",
+         ""
+        ],
+        [
+         "46",
+         "648.609",
+         "µm^3",
+         "Track",
+         "1000001002",
+         ""
+        ],
+        [
+         "47",
+         "648.609",
+         "µm^3",
+         "Track",
+         "1000001013",
+         ""
+        ],
+        [
+         "48",
+         "648.609",
+         "µm^3",
+         "Track",
+         "1000001033",
+         ""
+        ],
+        [
+         "49",
+         "648.609",
+         "µm^3",
+         "Track",
+         "1000001050",
+         ""
+        ]
+       ],
+       "shape": {
+        "columns": 5,
+        "rows": 756
+       }
+      },
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>Track Volume Mean</th>\n",
+       "      <th>Unit</th>\n",
+       "      <th>Category</th>\n",
+       "      <th>ID</th>\n",
+       "      <th></th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>0</th>\n",
+       "      <td>648.609</td>\n",
+       "      <td>µm^3</td>\n",
+       "      <td>Track</td>\n",
+       "      <td>1000000039</td>\n",
+       "      <td></td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>1</th>\n",
+       "      <td>648.609</td>\n",
+       "      <td>µm^3</td>\n",
+       "      <td>Track</td>\n",
+       "      <td>1000000042</td>\n",
+       "      <td></td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>2</th>\n",
+       "      <td>648.609</td>\n",
+       "      <td>µm^3</td>\n",
+       "      <td>Track</td>\n",
+       "      <td>1000000060</td>\n",
+       "      <td></td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>3</th>\n",
+       "      <td>648.609</td>\n",
+       "      <td>µm^3</td>\n",
+       "      <td>Track</td>\n",
+       "      <td>1000000065</td>\n",
+       "      <td></td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>4</th>\n",
+       "      <td>648.609</td>\n",
+       "      <td>µm^3</td>\n",
+       "      <td>Track</td>\n",
+       "      <td>1000000073</td>\n",
+       "      <td></td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>...</th>\n",
+       "      <td>...</td>\n",
+       "      <td>...</td>\n",
+       "      <td>...</td>\n",
+       "      <td>...</td>\n",
+       "      <td>...</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>751</th>\n",
+       "      <td>648.609</td>\n",
+       "      <td>µm^3</td>\n",
+       "      <td>Track</td>\n",
+       "      <td>1000654755</td>\n",
+       "      <td></td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>752</th>\n",
+       "      <td>648.609</td>\n",
+       "      <td>µm^3</td>\n",
+       "      <td>Track</td>\n",
+       "      <td>1000656003</td>\n",
+       "      <td></td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>753</th>\n",
+       "      <td>648.609</td>\n",
+       "      <td>µm^3</td>\n",
+       "      <td>Track</td>\n",
+       "      <td>1000664852</td>\n",
+       "      <td></td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>754</th>\n",
+       "      <td>648.609</td>\n",
+       "      <td>µm^3</td>\n",
+       "      <td>Track</td>\n",
+       "      <td>1000666870</td>\n",
+       "      <td></td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>755</th>\n",
+       "      <td>648.609</td>\n",
+       "      <td>µm^3</td>\n",
+       "      <td>Track</td>\n",
+       "      <td>1000682257</td>\n",
+       "      <td></td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "<p>756 rows × 5 columns</p>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "    Track Volume Mean  Unit Category          ID   \n",
+       "0             648.609  µm^3    Track  1000000039   \n",
+       "1             648.609  µm^3    Track  1000000042   \n",
+       "2             648.609  µm^3    Track  1000000060   \n",
+       "3             648.609  µm^3    Track  1000000065   \n",
+       "4             648.609  µm^3    Track  1000000073   \n",
+       "..                ...   ...      ...         ... ..\n",
+       "751           648.609  µm^3    Track  1000654755   \n",
+       "752           648.609  µm^3    Track  1000656003   \n",
+       "753           648.609  µm^3    Track  1000664852   \n",
+       "754           648.609  µm^3    Track  1000666870   \n",
+       "755           648.609  µm^3    Track  1000682257   \n",
+       "\n",
+       "[756 rows x 5 columns]"
+      ]
+     },
+     "execution_count": 6,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "def get_stats_df(path: str) -> Tuple[str, pd.DataFrame]:\n",
+    "    with open(path, newline=\"\", encoding=\"utf-8\") as f:\n",
+    "        reader = csv.reader(f)\n",
+    "        dataframe = []\n",
+    "        for row in reader:\n",
+    "            dataframe.append(row)\n",
+    "\n",
+    "    # get the stats name\n",
+    "    stat_name = dataframe[1][0]\n",
+    "\n",
+    "    # the first three rows from imaris export needs to be dropped\n",
+    "    dataframe = pd.DataFrame(dataframe[4:], columns=dataframe[3])\n",
+    "    # out = {stat_name: dataframe}\n",
+    "    return (stat_name, dataframe)\n",
+    "\n",
+    "\n",
+    "index = 6\n",
+    "items = get_stats_df(track_stats_files[index])\n",
+    "print(items[0], \"\\n\")\n",
+    "items[1]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "id": "bfeac502",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "13e6fc1a4d5c4b80b7fefbab97a527c8",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "  0%|          | 0/128 [00:00<?, ?it/s]"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "# get all the stat from the test files into a dict\n",
+    "test_stats_dict = {}\n",
+    "for stat_test_path in tqdm(track_stats_files):\n",
+    "    items = get_stats_df(stat_test_path)\n",
+    "    if items[0] in test_stats_dict.keys():\n",
+    "        raise ValueError\n",
+    "    else:\n",
+    "        test_stats_dict[items[0]] = items[1]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 127,
+   "id": "977ff9a8",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Num stats to evaluate: 52\n"
+     ]
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "cad2f6742da54b5daa891b4461e7b9a0",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "  0%|          | 0/52 [00:00<?, ?it/s]"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "print(f\"Num stats to evaluate: {len(parser_stat_names)}\")\n",
+    "\n",
+    "for stat_name in tqdm(parser_stat_names):\n",
+    "    # get test stats df\n",
+    "    if stat_name != \"Track_ID\":\n",
+    "\n",
+    "        test_df = test_stats_dict[stat_name]\n",
+    "\n",
+    "        # it seems like if channel and image information is given the df will modify its name\n",
+    "        # we need to drop these\n",
+    "        stat_name_our_df = None\n",
+    "        if \"Channel\" in list(test_df.columns) and \"Image\" in list(test_df.columns):\n",
+    "            index = stat_name.find(\"Ch=\") - 1\n",
+    "            stat_name_our_df = stat_name[:index]\n",
+    "\n",
+    "        if \"Spots\" in list(test_df.columns):\n",
+    "            if stat_name_our_df:\n",
+    "                index = stat_name_our_df.find(\"Spots=\") - 1\n",
+    "                stat_name_our_df = stat_name_our_df[:index]\n",
+    "            else:\n",
+    "                index = stat_name.find(\"Spots=\") - 1\n",
+    "                stat_name_our_df = stat_name[:index]\n",
+    "\n",
+    "        # get df to compare to\n",
+    "        if stat_name_our_df:\n",
+    "            test_df = test_stats_dict[stat_name].filter([stat_name_our_df, \"ID\"])\n",
+    "        else:\n",
+    "            test_df = test_stats_dict[stat_name].filter([stat_name, \"ID\"])\n",
+    "\n",
+    "        # get the df we generate\n",
+    "        our_df = parser_df.filter([stat_name, \"Track_ID\"]).rename(\n",
+    "            columns={\"Track_ID\": \"ID\"}\n",
+    "        )\n",
+    "        our_df = our_df.reset_index().drop(\"index\", axis=1)\n",
+    "        our_df[\"ID\"] = our_df[\"ID\"].astype(str)\n",
+    "        our_df[stat_name] = our_df[stat_name].astype(float).map(lambda x: f\"{x:.3f}\")\n",
+    "        our_df[stat_name] = our_df[stat_name].astype(str)\n",
+    "\n",
+    "        # it seems like if channel and image information is given the df will modify its name\n",
+    "        # we need to drop these\n",
+    "        if stat_name_our_df:\n",
+    "            our_df = our_df.rename(columns={stat_name: stat_name_our_df})\n",
+    "\n",
+    "        if not (test_df.equals(our_df)):\n",
+    "            print(stat_name)\n",
+    "            print(stat_name_our_df)\n",
+    "            break"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "7a25b05a",
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "84d9d379",
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "b64a3ce2",
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 122,
+   "id": "bb92ae49",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "application/vnd.microsoft.datawrangler.viewer.v0+json": {
+       "columns": [
+        {
+         "name": "index",
+         "rawType": "int64",
+         "type": "integer"
+        },
+        {
+         "name": "Track Intensity Center Mean",
+         "rawType": "object",
+         "type": "string"
+        },
+        {
+         "name": "ID",
+         "rawType": "object",
+         "type": "string"
+        }
+       ],
+       "ref": "f3e68c2c-668a-4bc6-a70d-d7aa0b610423",
+       "rows": [
+        [
+         "0",
+         "18.069",
+         "1000000039"
+        ],
+        [
+         "1",
+         "16.036",
+         "1000000042"
+        ],
+        [
+         "2",
+         "10.000",
+         "1000000060"
+        ],
+        [
+         "3",
+         "19.217",
+         "1000000065"
+        ],
+        [
+         "4",
+         "14.783",
+         "1000000073"
+        ],
+        [
+         "5",
+         "17.125",
+         "1000000083"
+        ],
+        [
+         "6",
+         "227.683",
+         "1000000085"
+        ],
+        [
+         "7",
+         "29.410",
+         "1000000091"
+        ],
+        [
+         "8",
+         "22.776",
+         "1000000110"
+        ],
+        [
+         "9",
+         "34.050",
+         "1000000114"
+        ],
+        [
+         "10",
+         "56.417",
+         "1000000120"
+        ],
+        [
+         "11",
+         "27.040",
+         "1000000135"
+        ],
+        [
+         "12",
+         "30.180",
+         "1000000151"
+        ],
+        [
+         "13",
+         "27.169",
+         "1000000161"
+        ],
+        [
+         "14",
+         "22.881",
+         "1000000170"
+        ],
+        [
+         "15",
+         "16.902",
+         "1000000179"
+        ],
+        [
+         "16",
+         "48.782",
+         "1000000188"
+        ],
+        [
+         "17",
+         "133.346",
+         "1000000189"
+        ],
+        [
+         "18",
+         "105.298",
+         "1000000190"
+        ],
+        [
+         "19",
+         "72.486",
+         "1000000193"
+        ],
+        [
+         "20",
+         "25.750",
+         "1000000195"
+        ],
+        [
+         "21",
+         "16.724",
+         "1000000199"
+        ],
+        [
+         "22",
+         "23.949",
+         "1000000200"
+        ],
+        [
+         "23",
+         "22.722",
+         "1000000239"
+        ],
+        [
+         "24",
+         "248.382",
+         "1000000265"
+        ],
+        [
+         "25",
+         "15.569",
+         "1000000317"
+        ],
+        [
+         "26",
+         "10.886",
+         "1000000391"
+        ],
+        [
+         "27",
+         "17.362",
+         "1000000399"
+        ],
+        [
+         "28",
+         "19.654",
+         "1000000410"
+        ],
+        [
+         "29",
+         "18.931",
+         "1000000496"
+        ],
+        [
+         "30",
+         "64.724",
+         "1000000557"
+        ],
+        [
+         "31",
+         "179.048",
+         "1000000562"
+        ],
+        [
+         "32",
+         "35.129",
+         "1000000569"
+        ],
+        [
+         "33",
+         "20.362",
+         "1000000570"
+        ],
+        [
+         "34",
+         "15.867",
+         "1000000573"
+        ],
+        [
+         "35",
+         "33.591",
+         "1000000581"
+        ],
+        [
+         "36",
+         "20.857",
+         "1000000587"
+        ],
+        [
+         "37",
+         "22.613",
+         "1000000588"
+        ],
+        [
+         "38",
+         "17.433",
+         "1000000590"
+        ],
+        [
+         "39",
+         "33.250",
+         "1000000611"
+        ],
+        [
+         "40",
+         "20.951",
+         "1000000620"
+        ],
+        [
+         "41",
+         "16.109",
+         "1000000745"
+        ],
+        [
+         "42",
+         "15.310",
+         "1000000751"
+        ],
+        [
+         "43",
+         "20.034",
+         "1000000759"
+        ],
+        [
+         "44",
+         "140.050",
+         "1000000766"
+        ],
+        [
+         "45",
+         "24.806",
+         "1000000947"
+        ],
+        [
+         "46",
+         "18.571",
+         "1000001002"
+        ],
+        [
+         "47",
+         "16.333",
+         "1000001013"
+        ],
+        [
+         "48",
+         "237.935",
+         "1000001033"
+        ],
+        [
+         "49",
+         "58.056",
+         "1000001050"
+        ]
+       ],
+       "shape": {
+        "columns": 2,
+        "rows": 756
+       }
+      },
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>Track Intensity Center Mean</th>\n",
+       "      <th>ID</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>0</th>\n",
+       "      <td>18.069</td>\n",
+       "      <td>1000000039</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>1</th>\n",
+       "      <td>16.036</td>\n",
+       "      <td>1000000042</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>2</th>\n",
+       "      <td>10.000</td>\n",
+       "      <td>1000000060</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>3</th>\n",
+       "      <td>19.217</td>\n",
+       "      <td>1000000065</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>4</th>\n",
+       "      <td>14.783</td>\n",
+       "      <td>1000000073</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>...</th>\n",
+       "      <td>...</td>\n",
+       "      <td>...</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>751</th>\n",
+       "      <td>9.286</td>\n",
+       "      <td>1000654755</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>752</th>\n",
+       "      <td>13.900</td>\n",
+       "      <td>1000656003</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>753</th>\n",
+       "      <td>19.250</td>\n",
+       "      <td>1000664852</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>754</th>\n",
+       "      <td>51.182</td>\n",
+       "      <td>1000666870</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>755</th>\n",
+       "      <td>12.750</td>\n",
+       "      <td>1000682257</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "<p>756 rows × 2 columns</p>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "    Track Intensity Center Mean          ID\n",
+       "0                        18.069  1000000039\n",
+       "1                        16.036  1000000042\n",
+       "2                        10.000  1000000060\n",
+       "3                        19.217  1000000065\n",
+       "4                        14.783  1000000073\n",
+       "..                          ...         ...\n",
+       "751                       9.286  1000654755\n",
+       "752                      13.900  1000656003\n",
+       "753                      19.250  1000664852\n",
+       "754                      51.182  1000666870\n",
+       "755                      12.750  1000682257\n",
+       "\n",
+       "[756 rows x 2 columns]"
+      ]
+     },
+     "execution_count": 122,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "our_df"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 125,
+   "id": "630adedc",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "application/vnd.microsoft.datawrangler.viewer.v0+json": {
+       "columns": [
+        {
+         "name": "index",
+         "rawType": "int64",
+         "type": "integer"
+        },
+        {
+         "name": "ID",
+         "rawType": "object",
+         "type": "string"
+        }
+       ],
+       "ref": "e470c6e4-4b60-482b-b0e8-2e47517f6546",
+       "rows": [
+        [
+         "0",
+         "1000000039"
+        ],
+        [
+         "1",
+         "1000000042"
+        ],
+        [
+         "2",
+         "1000000060"
+        ],
+        [
+         "3",
+         "1000000065"
+        ],
+        [
+         "4",
+         "1000000073"
+        ],
+        [
+         "5",
+         "1000000083"
+        ],
+        [
+         "6",
+         "1000000085"
+        ],
+        [
+         "7",
+         "1000000091"
+        ],
+        [
+         "8",
+         "1000000110"
+        ],
+        [
+         "9",
+         "1000000114"
+        ],
+        [
+         "10",
+         "1000000120"
+        ],
+        [
+         "11",
+         "1000000135"
+        ],
+        [
+         "12",
+         "1000000151"
+        ],
+        [
+         "13",
+         "1000000161"
+        ],
+        [
+         "14",
+         "1000000170"
+        ],
+        [
+         "15",
+         "1000000179"
+        ],
+        [
+         "16",
+         "1000000188"
+        ],
+        [
+         "17",
+         "1000000189"
+        ],
+        [
+         "18",
+         "1000000190"
+        ],
+        [
+         "19",
+         "1000000193"
+        ],
+        [
+         "20",
+         "1000000195"
+        ],
+        [
+         "21",
+         "1000000199"
+        ],
+        [
+         "22",
+         "1000000200"
+        ],
+        [
+         "23",
+         "1000000239"
+        ],
+        [
+         "24",
+         "1000000265"
+        ],
+        [
+         "25",
+         "1000000317"
+        ],
+        [
+         "26",
+         "1000000391"
+        ],
+        [
+         "27",
+         "1000000399"
+        ],
+        [
+         "28",
+         "1000000410"
+        ],
+        [
+         "29",
+         "1000000496"
+        ],
+        [
+         "30",
+         "1000000557"
+        ],
+        [
+         "31",
+         "1000000562"
+        ],
+        [
+         "32",
+         "1000000569"
+        ],
+        [
+         "33",
+         "1000000570"
+        ],
+        [
+         "34",
+         "1000000573"
+        ],
+        [
+         "35",
+         "1000000581"
+        ],
+        [
+         "36",
+         "1000000587"
+        ],
+        [
+         "37",
+         "1000000588"
+        ],
+        [
+         "38",
+         "1000000590"
+        ],
+        [
+         "39",
+         "1000000611"
+        ],
+        [
+         "40",
+         "1000000620"
+        ],
+        [
+         "41",
+         "1000000745"
+        ],
+        [
+         "42",
+         "1000000751"
+        ],
+        [
+         "43",
+         "1000000759"
+        ],
+        [
+         "44",
+         "1000000766"
+        ],
+        [
+         "45",
+         "1000000947"
+        ],
+        [
+         "46",
+         "1000001002"
+        ],
+        [
+         "47",
+         "1000001013"
+        ],
+        [
+         "48",
+         "1000001033"
+        ],
+        [
+         "49",
+         "1000001050"
+        ]
+       ],
+       "shape": {
+        "columns": 1,
+        "rows": 756
+       }
+      },
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>ID</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>0</th>\n",
+       "      <td>1000000039</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>1</th>\n",
+       "      <td>1000000042</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>2</th>\n",
+       "      <td>1000000060</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>3</th>\n",
+       "      <td>1000000065</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>4</th>\n",
+       "      <td>1000000073</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>...</th>\n",
+       "      <td>...</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>751</th>\n",
+       "      <td>1000654755</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>752</th>\n",
+       "      <td>1000656003</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>753</th>\n",
+       "      <td>1000664852</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>754</th>\n",
+       "      <td>1000666870</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>755</th>\n",
+       "      <td>1000682257</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "<p>756 rows × 1 columns</p>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "             ID\n",
+       "0    1000000039\n",
+       "1    1000000042\n",
+       "2    1000000060\n",
+       "3    1000000065\n",
+       "4    1000000073\n",
+       "..          ...\n",
+       "751  1000654755\n",
+       "752  1000656003\n",
+       "753  1000664852\n",
+       "754  1000666870\n",
+       "755  1000682257\n",
+       "\n",
+       "[756 rows x 1 columns]"
+      ]
+     },
+     "execution_count": 125,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "test_df"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 92,
+   "id": "f88664e3",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "application/vnd.microsoft.datawrangler.viewer.v0+json": {
+       "columns": [
+        {
+         "name": "index",
+         "rawType": "int64",
+         "type": "integer"
+        },
+        {
+         "name": "Track Intensity Center Mean",
+         "rawType": "object",
+         "type": "string"
+        },
+        {
+         "name": "Unit",
+         "rawType": "object",
+         "type": "string"
+        },
+        {
+         "name": "Category",
+         "rawType": "object",
+         "type": "string"
+        },
+        {
+         "name": "Channel",
+         "rawType": "object",
+         "type": "string"
+        },
+        {
+         "name": "Image",
+         "rawType": "object",
+         "type": "string"
+        },
+        {
+         "name": "ID",
+         "rawType": "object",
+         "type": "string"
+        },
+        {
+         "name": "",
+         "rawType": "object",
+         "type": "string"
+        }
+       ],
+       "ref": "1a4de654-a50b-457e-b0b5-fd09ad58e908",
+       "rows": [
+        [
+         "0",
+         "18.069",
+         "",
+         "Track",
+         "1",
+         "Image 1",
+         "1000000039",
+         ""
+        ],
+        [
+         "1",
+         "16.036",
+         "",
+         "Track",
+         "1",
+         "Image 1",
+         "1000000042",
+         ""
+        ],
+        [
+         "2",
+         "10.000",
+         "",
+         "Track",
+         "1",
+         "Image 1",
+         "1000000060",
+         ""
+        ],
+        [
+         "3",
+         "19.217",
+         "",
+         "Track",
+         "1",
+         "Image 1",
+         "1000000065",
+         ""
+        ],
+        [
+         "4",
+         "14.783",
+         "",
+         "Track",
+         "1",
+         "Image 1",
+         "1000000073",
+         ""
+        ],
+        [
+         "5",
+         "17.125",
+         "",
+         "Track",
+         "1",
+         "Image 1",
+         "1000000083",
+         ""
+        ],
+        [
+         "6",
+         "227.683",
+         "",
+         "Track",
+         "1",
+         "Image 1",
+         "1000000085",
+         ""
+        ],
+        [
+         "7",
+         "29.410",
+         "",
+         "Track",
+         "1",
+         "Image 1",
+         "1000000091",
+         ""
+        ],
+        [
+         "8",
+         "22.776",
+         "",
+         "Track",
+         "1",
+         "Image 1",
+         "1000000110",
+         ""
+        ],
+        [
+         "9",
+         "34.050",
+         "",
+         "Track",
+         "1",
+         "Image 1",
+         "1000000114",
+         ""
+        ],
+        [
+         "10",
+         "56.417",
+         "",
+         "Track",
+         "1",
+         "Image 1",
+         "1000000120",
+         ""
+        ],
+        [
+         "11",
+         "27.040",
+         "",
+         "Track",
+         "1",
+         "Image 1",
+         "1000000135",
+         ""
+        ],
+        [
+         "12",
+         "30.180",
+         "",
+         "Track",
+         "1",
+         "Image 1",
+         "1000000151",
+         ""
+        ],
+        [
+         "13",
+         "27.169",
+         "",
+         "Track",
+         "1",
+         "Image 1",
+         "1000000161",
+         ""
+        ],
+        [
+         "14",
+         "22.881",
+         "",
+         "Track",
+         "1",
+         "Image 1",
+         "1000000170",
+         ""
+        ],
+        [
+         "15",
+         "16.902",
+         "",
+         "Track",
+         "1",
+         "Image 1",
+         "1000000179",
+         ""
+        ],
+        [
+         "16",
+         "48.782",
+         "",
+         "Track",
+         "1",
+         "Image 1",
+         "1000000188",
+         ""
+        ],
+        [
+         "17",
+         "133.346",
+         "",
+         "Track",
+         "1",
+         "Image 1",
+         "1000000189",
+         ""
+        ],
+        [
+         "18",
+         "105.298",
+         "",
+         "Track",
+         "1",
+         "Image 1",
+         "1000000190",
+         ""
+        ],
+        [
+         "19",
+         "72.486",
+         "",
+         "Track",
+         "1",
+         "Image 1",
+         "1000000193",
+         ""
+        ],
+        [
+         "20",
+         "25.750",
+         "",
+         "Track",
+         "1",
+         "Image 1",
+         "1000000195",
+         ""
+        ],
+        [
+         "21",
+         "16.724",
+         "",
+         "Track",
+         "1",
+         "Image 1",
+         "1000000199",
+         ""
+        ],
+        [
+         "22",
+         "23.949",
+         "",
+         "Track",
+         "1",
+         "Image 1",
+         "1000000200",
+         ""
+        ],
+        [
+         "23",
+         "22.722",
+         "",
+         "Track",
+         "1",
+         "Image 1",
+         "1000000239",
+         ""
+        ],
+        [
+         "24",
+         "248.382",
+         "",
+         "Track",
+         "1",
+         "Image 1",
+         "1000000265",
+         ""
+        ],
+        [
+         "25",
+         "15.569",
+         "",
+         "Track",
+         "1",
+         "Image 1",
+         "1000000317",
+         ""
+        ],
+        [
+         "26",
+         "10.886",
+         "",
+         "Track",
+         "1",
+         "Image 1",
+         "1000000391",
+         ""
+        ],
+        [
+         "27",
+         "17.362",
+         "",
+         "Track",
+         "1",
+         "Image 1",
+         "1000000399",
+         ""
+        ],
+        [
+         "28",
+         "19.654",
+         "",
+         "Track",
+         "1",
+         "Image 1",
+         "1000000410",
+         ""
+        ],
+        [
+         "29",
+         "18.931",
+         "",
+         "Track",
+         "1",
+         "Image 1",
+         "1000000496",
+         ""
+        ],
+        [
+         "30",
+         "64.724",
+         "",
+         "Track",
+         "1",
+         "Image 1",
+         "1000000557",
+         ""
+        ],
+        [
+         "31",
+         "179.048",
+         "",
+         "Track",
+         "1",
+         "Image 1",
+         "1000000562",
+         ""
+        ],
+        [
+         "32",
+         "35.129",
+         "",
+         "Track",
+         "1",
+         "Image 1",
+         "1000000569",
+         ""
+        ],
+        [
+         "33",
+         "20.362",
+         "",
+         "Track",
+         "1",
+         "Image 1",
+         "1000000570",
+         ""
+        ],
+        [
+         "34",
+         "15.867",
+         "",
+         "Track",
+         "1",
+         "Image 1",
+         "1000000573",
+         ""
+        ],
+        [
+         "35",
+         "33.591",
+         "",
+         "Track",
+         "1",
+         "Image 1",
+         "1000000581",
+         ""
+        ],
+        [
+         "36",
+         "20.857",
+         "",
+         "Track",
+         "1",
+         "Image 1",
+         "1000000587",
+         ""
+        ],
+        [
+         "37",
+         "22.613",
+         "",
+         "Track",
+         "1",
+         "Image 1",
+         "1000000588",
+         ""
+        ],
+        [
+         "38",
+         "17.433",
+         "",
+         "Track",
+         "1",
+         "Image 1",
+         "1000000590",
+         ""
+        ],
+        [
+         "39",
+         "33.250",
+         "",
+         "Track",
+         "1",
+         "Image 1",
+         "1000000611",
+         ""
+        ],
+        [
+         "40",
+         "20.951",
+         "",
+         "Track",
+         "1",
+         "Image 1",
+         "1000000620",
+         ""
+        ],
+        [
+         "41",
+         "16.109",
+         "",
+         "Track",
+         "1",
+         "Image 1",
+         "1000000745",
+         ""
+        ],
+        [
+         "42",
+         "15.310",
+         "",
+         "Track",
+         "1",
+         "Image 1",
+         "1000000751",
+         ""
+        ],
+        [
+         "43",
+         "20.034",
+         "",
+         "Track",
+         "1",
+         "Image 1",
+         "1000000759",
+         ""
+        ],
+        [
+         "44",
+         "140.050",
+         "",
+         "Track",
+         "1",
+         "Image 1",
+         "1000000766",
+         ""
+        ],
+        [
+         "45",
+         "24.806",
+         "",
+         "Track",
+         "1",
+         "Image 1",
+         "1000000947",
+         ""
+        ],
+        [
+         "46",
+         "18.571",
+         "",
+         "Track",
+         "1",
+         "Image 1",
+         "1000001002",
+         ""
+        ],
+        [
+         "47",
+         "16.333",
+         "",
+         "Track",
+         "1",
+         "Image 1",
+         "1000001013",
+         ""
+        ],
+        [
+         "48",
+         "237.935",
+         "",
+         "Track",
+         "1",
+         "Image 1",
+         "1000001033",
+         ""
+        ],
+        [
+         "49",
+         "58.056",
+         "",
+         "Track",
+         "1",
+         "Image 1",
+         "1000001050",
+         ""
+        ]
+       ],
+       "shape": {
+        "columns": 7,
+        "rows": 756
+       }
+      },
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>Track Intensity Center Mean</th>\n",
+       "      <th>Unit</th>\n",
+       "      <th>Category</th>\n",
+       "      <th>Channel</th>\n",
+       "      <th>Image</th>\n",
+       "      <th>ID</th>\n",
+       "      <th></th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>0</th>\n",
+       "      <td>18.069</td>\n",
+       "      <td></td>\n",
+       "      <td>Track</td>\n",
+       "      <td>1</td>\n",
+       "      <td>Image 1</td>\n",
+       "      <td>1000000039</td>\n",
+       "      <td></td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>1</th>\n",
+       "      <td>16.036</td>\n",
+       "      <td></td>\n",
+       "      <td>Track</td>\n",
+       "      <td>1</td>\n",
+       "      <td>Image 1</td>\n",
+       "      <td>1000000042</td>\n",
+       "      <td></td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>2</th>\n",
+       "      <td>10.000</td>\n",
+       "      <td></td>\n",
+       "      <td>Track</td>\n",
+       "      <td>1</td>\n",
+       "      <td>Image 1</td>\n",
+       "      <td>1000000060</td>\n",
+       "      <td></td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>3</th>\n",
+       "      <td>19.217</td>\n",
+       "      <td></td>\n",
+       "      <td>Track</td>\n",
+       "      <td>1</td>\n",
+       "      <td>Image 1</td>\n",
+       "      <td>1000000065</td>\n",
+       "      <td></td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>4</th>\n",
+       "      <td>14.783</td>\n",
+       "      <td></td>\n",
+       "      <td>Track</td>\n",
+       "      <td>1</td>\n",
+       "      <td>Image 1</td>\n",
+       "      <td>1000000073</td>\n",
+       "      <td></td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>...</th>\n",
+       "      <td>...</td>\n",
+       "      <td>...</td>\n",
+       "      <td>...</td>\n",
+       "      <td>...</td>\n",
+       "      <td>...</td>\n",
+       "      <td>...</td>\n",
+       "      <td>...</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>751</th>\n",
+       "      <td>9.286</td>\n",
+       "      <td></td>\n",
+       "      <td>Track</td>\n",
+       "      <td>1</td>\n",
+       "      <td>Image 1</td>\n",
+       "      <td>1000654755</td>\n",
+       "      <td></td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>752</th>\n",
+       "      <td>13.900</td>\n",
+       "      <td></td>\n",
+       "      <td>Track</td>\n",
+       "      <td>1</td>\n",
+       "      <td>Image 1</td>\n",
+       "      <td>1000656003</td>\n",
+       "      <td></td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>753</th>\n",
+       "      <td>19.250</td>\n",
+       "      <td></td>\n",
+       "      <td>Track</td>\n",
+       "      <td>1</td>\n",
+       "      <td>Image 1</td>\n",
+       "      <td>1000664852</td>\n",
+       "      <td></td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>754</th>\n",
+       "      <td>51.182</td>\n",
+       "      <td></td>\n",
+       "      <td>Track</td>\n",
+       "      <td>1</td>\n",
+       "      <td>Image 1</td>\n",
+       "      <td>1000666870</td>\n",
+       "      <td></td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>755</th>\n",
+       "      <td>12.750</td>\n",
+       "      <td></td>\n",
+       "      <td>Track</td>\n",
+       "      <td>1</td>\n",
+       "      <td>Image 1</td>\n",
+       "      <td>1000682257</td>\n",
+       "      <td></td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "<p>756 rows × 7 columns</p>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "    Track Intensity Center Mean Unit Category Channel    Image          ID   \n",
+       "0                        18.069         Track       1  Image 1  1000000039   \n",
+       "1                        16.036         Track       1  Image 1  1000000042   \n",
+       "2                        10.000         Track       1  Image 1  1000000060   \n",
+       "3                        19.217         Track       1  Image 1  1000000065   \n",
+       "4                        14.783         Track       1  Image 1  1000000073   \n",
+       "..                          ...  ...      ...     ...      ...         ... ..\n",
+       "751                       9.286         Track       1  Image 1  1000654755   \n",
+       "752                      13.900         Track       1  Image 1  1000656003   \n",
+       "753                      19.250         Track       1  Image 1  1000664852   \n",
+       "754                      51.182         Track       1  Image 1  1000666870   \n",
+       "755                      12.750         Track       1  Image 1  1000682257   \n",
+       "\n",
+       "[756 rows x 7 columns]"
+      ]
+     },
+     "execution_count": 92,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "t = test_stats_dict[\"Track Intensity Center Mean Ch=1 Img=1\"]\n",
+    "o = parser_df.filter([\"Track Intensity Sum Ch=3 Img=1\", \"Track_ID\"]).rename(\n",
+    "    columns={\"Track_ID\": \"ID\"}\n",
+    ")\n",
+    "t"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 93,
+   "id": "9f06bf74",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "stat_name = \"Track Intensity Center Mean\""
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "b399ddd6",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "if \"Channel\" in list(t.columns) and \"Image\" in list(t.columns):\n",
+    "    stat_name_new = (\n",
+    "        f\"{stat_name} Ch={t.iloc[0]['Channel']} Img={t.iloc[0]['Image'].split(\" \")[-1]}\"\n",
+    "    )\n",
+    "    t = t.rename(columns={stat_name: stat_name_new})"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 95,
+   "id": "4efc7eae",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "application/vnd.microsoft.datawrangler.viewer.v0+json": {
+       "columns": [
+        {
+         "name": "index",
+         "rawType": "int64",
+         "type": "integer"
+        },
+        {
+         "name": "Track Intensity Center Mean Ch=1 Img=1",
+         "rawType": "object",
+         "type": "string"
+        },
+        {
+         "name": "Unit",
+         "rawType": "object",
+         "type": "string"
+        },
+        {
+         "name": "Category",
+         "rawType": "object",
+         "type": "string"
+        },
+        {
+         "name": "Channel",
+         "rawType": "object",
+         "type": "string"
+        },
+        {
+         "name": "Image",
+         "rawType": "object",
+         "type": "string"
+        },
+        {
+         "name": "ID",
+         "rawType": "object",
+         "type": "string"
+        },
+        {
+         "name": "",
+         "rawType": "object",
+         "type": "string"
+        }
+       ],
+       "ref": "3f9365bc-09ab-421c-8d54-be66b607b81c",
+       "rows": [
+        [
+         "0",
+         "18.069",
+         "",
+         "Track",
+         "1",
+         "Image 1",
+         "1000000039",
+         ""
+        ],
+        [
+         "1",
+         "16.036",
+         "",
+         "Track",
+         "1",
+         "Image 1",
+         "1000000042",
+         ""
+        ],
+        [
+         "2",
+         "10.000",
+         "",
+         "Track",
+         "1",
+         "Image 1",
+         "1000000060",
+         ""
+        ],
+        [
+         "3",
+         "19.217",
+         "",
+         "Track",
+         "1",
+         "Image 1",
+         "1000000065",
+         ""
+        ],
+        [
+         "4",
+         "14.783",
+         "",
+         "Track",
+         "1",
+         "Image 1",
+         "1000000073",
+         ""
+        ],
+        [
+         "5",
+         "17.125",
+         "",
+         "Track",
+         "1",
+         "Image 1",
+         "1000000083",
+         ""
+        ],
+        [
+         "6",
+         "227.683",
+         "",
+         "Track",
+         "1",
+         "Image 1",
+         "1000000085",
+         ""
+        ],
+        [
+         "7",
+         "29.410",
+         "",
+         "Track",
+         "1",
+         "Image 1",
+         "1000000091",
+         ""
+        ],
+        [
+         "8",
+         "22.776",
+         "",
+         "Track",
+         "1",
+         "Image 1",
+         "1000000110",
+         ""
+        ],
+        [
+         "9",
+         "34.050",
+         "",
+         "Track",
+         "1",
+         "Image 1",
+         "1000000114",
+         ""
+        ],
+        [
+         "10",
+         "56.417",
+         "",
+         "Track",
+         "1",
+         "Image 1",
+         "1000000120",
+         ""
+        ],
+        [
+         "11",
+         "27.040",
+         "",
+         "Track",
+         "1",
+         "Image 1",
+         "1000000135",
+         ""
+        ],
+        [
+         "12",
+         "30.180",
+         "",
+         "Track",
+         "1",
+         "Image 1",
+         "1000000151",
+         ""
+        ],
+        [
+         "13",
+         "27.169",
+         "",
+         "Track",
+         "1",
+         "Image 1",
+         "1000000161",
+         ""
+        ],
+        [
+         "14",
+         "22.881",
+         "",
+         "Track",
+         "1",
+         "Image 1",
+         "1000000170",
+         ""
+        ],
+        [
+         "15",
+         "16.902",
+         "",
+         "Track",
+         "1",
+         "Image 1",
+         "1000000179",
+         ""
+        ],
+        [
+         "16",
+         "48.782",
+         "",
+         "Track",
+         "1",
+         "Image 1",
+         "1000000188",
+         ""
+        ],
+        [
+         "17",
+         "133.346",
+         "",
+         "Track",
+         "1",
+         "Image 1",
+         "1000000189",
+         ""
+        ],
+        [
+         "18",
+         "105.298",
+         "",
+         "Track",
+         "1",
+         "Image 1",
+         "1000000190",
+         ""
+        ],
+        [
+         "19",
+         "72.486",
+         "",
+         "Track",
+         "1",
+         "Image 1",
+         "1000000193",
+         ""
+        ],
+        [
+         "20",
+         "25.750",
+         "",
+         "Track",
+         "1",
+         "Image 1",
+         "1000000195",
+         ""
+        ],
+        [
+         "21",
+         "16.724",
+         "",
+         "Track",
+         "1",
+         "Image 1",
+         "1000000199",
+         ""
+        ],
+        [
+         "22",
+         "23.949",
+         "",
+         "Track",
+         "1",
+         "Image 1",
+         "1000000200",
+         ""
+        ],
+        [
+         "23",
+         "22.722",
+         "",
+         "Track",
+         "1",
+         "Image 1",
+         "1000000239",
+         ""
+        ],
+        [
+         "24",
+         "248.382",
+         "",
+         "Track",
+         "1",
+         "Image 1",
+         "1000000265",
+         ""
+        ],
+        [
+         "25",
+         "15.569",
+         "",
+         "Track",
+         "1",
+         "Image 1",
+         "1000000317",
+         ""
+        ],
+        [
+         "26",
+         "10.886",
+         "",
+         "Track",
+         "1",
+         "Image 1",
+         "1000000391",
+         ""
+        ],
+        [
+         "27",
+         "17.362",
+         "",
+         "Track",
+         "1",
+         "Image 1",
+         "1000000399",
+         ""
+        ],
+        [
+         "28",
+         "19.654",
+         "",
+         "Track",
+         "1",
+         "Image 1",
+         "1000000410",
+         ""
+        ],
+        [
+         "29",
+         "18.931",
+         "",
+         "Track",
+         "1",
+         "Image 1",
+         "1000000496",
+         ""
+        ],
+        [
+         "30",
+         "64.724",
+         "",
+         "Track",
+         "1",
+         "Image 1",
+         "1000000557",
+         ""
+        ],
+        [
+         "31",
+         "179.048",
+         "",
+         "Track",
+         "1",
+         "Image 1",
+         "1000000562",
+         ""
+        ],
+        [
+         "32",
+         "35.129",
+         "",
+         "Track",
+         "1",
+         "Image 1",
+         "1000000569",
+         ""
+        ],
+        [
+         "33",
+         "20.362",
+         "",
+         "Track",
+         "1",
+         "Image 1",
+         "1000000570",
+         ""
+        ],
+        [
+         "34",
+         "15.867",
+         "",
+         "Track",
+         "1",
+         "Image 1",
+         "1000000573",
+         ""
+        ],
+        [
+         "35",
+         "33.591",
+         "",
+         "Track",
+         "1",
+         "Image 1",
+         "1000000581",
+         ""
+        ],
+        [
+         "36",
+         "20.857",
+         "",
+         "Track",
+         "1",
+         "Image 1",
+         "1000000587",
+         ""
+        ],
+        [
+         "37",
+         "22.613",
+         "",
+         "Track",
+         "1",
+         "Image 1",
+         "1000000588",
+         ""
+        ],
+        [
+         "38",
+         "17.433",
+         "",
+         "Track",
+         "1",
+         "Image 1",
+         "1000000590",
+         ""
+        ],
+        [
+         "39",
+         "33.250",
+         "",
+         "Track",
+         "1",
+         "Image 1",
+         "1000000611",
+         ""
+        ],
+        [
+         "40",
+         "20.951",
+         "",
+         "Track",
+         "1",
+         "Image 1",
+         "1000000620",
+         ""
+        ],
+        [
+         "41",
+         "16.109",
+         "",
+         "Track",
+         "1",
+         "Image 1",
+         "1000000745",
+         ""
+        ],
+        [
+         "42",
+         "15.310",
+         "",
+         "Track",
+         "1",
+         "Image 1",
+         "1000000751",
+         ""
+        ],
+        [
+         "43",
+         "20.034",
+         "",
+         "Track",
+         "1",
+         "Image 1",
+         "1000000759",
+         ""
+        ],
+        [
+         "44",
+         "140.050",
+         "",
+         "Track",
+         "1",
+         "Image 1",
+         "1000000766",
+         ""
+        ],
+        [
+         "45",
+         "24.806",
+         "",
+         "Track",
+         "1",
+         "Image 1",
+         "1000000947",
+         ""
+        ],
+        [
+         "46",
+         "18.571",
+         "",
+         "Track",
+         "1",
+         "Image 1",
+         "1000001002",
+         ""
+        ],
+        [
+         "47",
+         "16.333",
+         "",
+         "Track",
+         "1",
+         "Image 1",
+         "1000001013",
+         ""
+        ],
+        [
+         "48",
+         "237.935",
+         "",
+         "Track",
+         "1",
+         "Image 1",
+         "1000001033",
+         ""
+        ],
+        [
+         "49",
+         "58.056",
+         "",
+         "Track",
+         "1",
+         "Image 1",
+         "1000001050",
+         ""
+        ]
+       ],
+       "shape": {
+        "columns": 7,
+        "rows": 756
+       }
+      },
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>Track Intensity Center Mean Ch=1 Img=1</th>\n",
+       "      <th>Unit</th>\n",
+       "      <th>Category</th>\n",
+       "      <th>Channel</th>\n",
+       "      <th>Image</th>\n",
+       "      <th>ID</th>\n",
+       "      <th></th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>0</th>\n",
+       "      <td>18.069</td>\n",
+       "      <td></td>\n",
+       "      <td>Track</td>\n",
+       "      <td>1</td>\n",
+       "      <td>Image 1</td>\n",
+       "      <td>1000000039</td>\n",
+       "      <td></td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>1</th>\n",
+       "      <td>16.036</td>\n",
+       "      <td></td>\n",
+       "      <td>Track</td>\n",
+       "      <td>1</td>\n",
+       "      <td>Image 1</td>\n",
+       "      <td>1000000042</td>\n",
+       "      <td></td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>2</th>\n",
+       "      <td>10.000</td>\n",
+       "      <td></td>\n",
+       "      <td>Track</td>\n",
+       "      <td>1</td>\n",
+       "      <td>Image 1</td>\n",
+       "      <td>1000000060</td>\n",
+       "      <td></td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>3</th>\n",
+       "      <td>19.217</td>\n",
+       "      <td></td>\n",
+       "      <td>Track</td>\n",
+       "      <td>1</td>\n",
+       "      <td>Image 1</td>\n",
+       "      <td>1000000065</td>\n",
+       "      <td></td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>4</th>\n",
+       "      <td>14.783</td>\n",
+       "      <td></td>\n",
+       "      <td>Track</td>\n",
+       "      <td>1</td>\n",
+       "      <td>Image 1</td>\n",
+       "      <td>1000000073</td>\n",
+       "      <td></td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>...</th>\n",
+       "      <td>...</td>\n",
+       "      <td>...</td>\n",
+       "      <td>...</td>\n",
+       "      <td>...</td>\n",
+       "      <td>...</td>\n",
+       "      <td>...</td>\n",
+       "      <td>...</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>751</th>\n",
+       "      <td>9.286</td>\n",
+       "      <td></td>\n",
+       "      <td>Track</td>\n",
+       "      <td>1</td>\n",
+       "      <td>Image 1</td>\n",
+       "      <td>1000654755</td>\n",
+       "      <td></td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>752</th>\n",
+       "      <td>13.900</td>\n",
+       "      <td></td>\n",
+       "      <td>Track</td>\n",
+       "      <td>1</td>\n",
+       "      <td>Image 1</td>\n",
+       "      <td>1000656003</td>\n",
+       "      <td></td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>753</th>\n",
+       "      <td>19.250</td>\n",
+       "      <td></td>\n",
+       "      <td>Track</td>\n",
+       "      <td>1</td>\n",
+       "      <td>Image 1</td>\n",
+       "      <td>1000664852</td>\n",
+       "      <td></td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>754</th>\n",
+       "      <td>51.182</td>\n",
+       "      <td></td>\n",
+       "      <td>Track</td>\n",
+       "      <td>1</td>\n",
+       "      <td>Image 1</td>\n",
+       "      <td>1000666870</td>\n",
+       "      <td></td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>755</th>\n",
+       "      <td>12.750</td>\n",
+       "      <td></td>\n",
+       "      <td>Track</td>\n",
+       "      <td>1</td>\n",
+       "      <td>Image 1</td>\n",
+       "      <td>1000682257</td>\n",
+       "      <td></td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "<p>756 rows × 7 columns</p>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "    Track Intensity Center Mean Ch=1 Img=1 Unit Category Channel    Image  \\\n",
+       "0                                   18.069         Track       1  Image 1   \n",
+       "1                                   16.036         Track       1  Image 1   \n",
+       "2                                   10.000         Track       1  Image 1   \n",
+       "3                                   19.217         Track       1  Image 1   \n",
+       "4                                   14.783         Track       1  Image 1   \n",
+       "..                                     ...  ...      ...     ...      ...   \n",
+       "751                                  9.286         Track       1  Image 1   \n",
+       "752                                 13.900         Track       1  Image 1   \n",
+       "753                                 19.250         Track       1  Image 1   \n",
+       "754                                 51.182         Track       1  Image 1   \n",
+       "755                                 12.750         Track       1  Image 1   \n",
+       "\n",
+       "             ID     \n",
+       "0    1000000039     \n",
+       "1    1000000042     \n",
+       "2    1000000060     \n",
+       "3    1000000065     \n",
+       "4    1000000073     \n",
+       "..          ... ..  \n",
+       "751  1000654755     \n",
+       "752  1000656003     \n",
+       "753  1000664852     \n",
+       "754  1000666870     \n",
+       "755  1000682257     \n",
+       "\n",
+       "[756 rows x 7 columns]"
+      ]
+     },
+     "execution_count": 95,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "t"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 63,
+   "id": "8b9bc6f3",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "stat_name = f\"{stat_name} Ch={t.iloc[0]}\""
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 24,
+   "id": "a4b4401a",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "['Track Intensity Median Ch=3 Img=1',\n",
+       " 'Displacement Delta Length',\n",
+       " 'Track Intensity Max Ch=3 Img=1',\n",
+       " 'Speed',\n",
+       " 'Time Index',\n",
+       " 'Time',\n",
+       " 'Track Volume Mean',\n",
+       " 'Track Intensity Max Ch=1 Img=1',\n",
+       " 'Intensity Center Ch=3 Img=1',\n",
+       " 'Average Distance To 9 Nearest Neighbours',\n",
+       " 'Track Displacement Length',\n",
+       " 'Track Position Start',\n",
+       " 'Intensity Sum of Square Ch=2 Img=1',\n",
+       " 'Distance To Nearest Neighbour',\n",
+       " 'Intensity Sum Ch=2 Img=1',\n",
+       " 'Position Y',\n",
+       " 'Intensity Sum Ch=3 Img=1',\n",
+       " 'Track Intensity Median Ch=1 Img=1',\n",
+       " 'Track Speed Mean',\n",
+       " 'Displacement Length',\n",
+       " 'Distance to Image Border XY Img=1',\n",
+       " 'Intensity Min Ch=1 Img=1',\n",
+       " 'Displacement Delta',\n",
+       " 'Track Straightness',\n",
+       " 'Track Intensity Sum Ch=2 Img=1',\n",
+       " 'Intensity Sum Ch=1 Img=1',\n",
+       " 'Track Intensity Median Ch=2 Img=1',\n",
+       " 'Track Number of Fusions',\n",
+       " 'Position Z',\n",
+       " 'Track Intensity Sum Ch=3 Img=1',\n",
+       " 'Intensity Min Ch=2 Img=1',\n",
+       " 'Average Distance To 5 Nearest Neighbours',\n",
+       " 'Intensity Center Ch=1 Img=1',\n",
+       " 'Displacement X',\n",
+       " 'Track Position',\n",
+       " 'Track Intensity Center Mean Ch=3 Img=1',\n",
+       " 'Area',\n",
+       " 'Intensity Max Ch=1 Img=1',\n",
+       " 'Track Length',\n",
+       " 'Track Intensity Sum Ch=1 Img=1',\n",
+       " 'Acceleration',\n",
+       " 'Track Duration',\n",
+       " 'Track Ar1',\n",
+       " 'Track Intensity Center Mean Ch=1 Img=1',\n",
+       " 'Displacement Delta Z',\n",
+       " 'Intensity Mean Ch=3 Img=1',\n",
+       " 'Diameter X',\n",
+       " 'Displacement Delta X',\n",
+       " 'Diameter Z',\n",
+       " 'Track Speed Min',\n",
+       " 'Velocity Angle X',\n",
+       " 'Distance to Image Border XYZ Img=1',\n",
+       " 'Displacement Y',\n",
+       " 'Track Shortest Distance to Spots Min Spots=Spots Unnamed 1 spots.icsx_[ibrx_2025-08-05T15-14-37.820]',\n",
+       " 'Intensity Min Ch=3 Img=1',\n",
+       " 'Intensity Max Ch=3 Img=1',\n",
+       " 'Track Ar1 Mean',\n",
+       " 'Intensity Mean Ch=1 Img=1',\n",
+       " 'Position X',\n",
+       " 'Track Position X Mean',\n",
+       " 'Track Area Mean',\n",
+       " 'Intensity Center Ch=2 Img=1',\n",
+       " 'Volume',\n",
+       " 'Track Intensity StdDev Ch=3 Img=1',\n",
+       " 'Track Intensity Mean Ch=3 Img=1',\n",
+       " 'Acceleration Z',\n",
+       " 'Displacement^2',\n",
+       " 'Track Ar1 X',\n",
+       " 'Number of Voxels Img=1',\n",
+       " 'Track Intensity Mean Ch=2 Img=1',\n",
+       " 'Intensity Median Ch=1 Img=1',\n",
+       " 'Distance from Origin',\n",
+       " 'Track Speed StdDev',\n",
+       " 'Intensity StdDev Ch=1 Img=1',\n",
+       " 'Intensity Median Ch=3 Img=1',\n",
+       " 'Track Displacement X',\n",
+       " 'Track Intensity StdDev Ch=1 Img=1',\n",
+       " 'Generation',\n",
+       " 'Track Intensity Center Mean Ch=2 Img=1',\n",
+       " 'Intensity Mean Ch=2 Img=1',\n",
+       " 'Track Ar1 Y',\n",
+       " 'Position',\n",
+       " 'Intensity Median Ch=2 Img=1',\n",
+       " 'Track Number of Spots',\n",
+       " 'Diameter Y',\n",
+       " 'Acceleration Y',\n",
+       " 'Shortest Distance to Spots Spots=Spots Unnamed 1 spots.icsx_[ibrx_2025-08-05T15-14-37.820]',\n",
+       " 'Velocity Z',\n",
+       " 'Time Since Track Start',\n",
+       " 'Track Displacement Y',\n",
+       " 'Track Position Y Start',\n",
+       " 'Velocity Angle',\n",
+       " 'Intensity Sum of Square Ch=1 Img=1',\n",
+       " 'Intensity StdDev Ch=3 Img=1',\n",
+       " 'Intensity StdDev Ch=2 Img=1',\n",
+       " 'Track Position X Start',\n",
+       " 'Track Intensity StdDev Ch=2 Img=1',\n",
+       " 'Acceleration X',\n",
+       " 'Track Displacement Z',\n",
+       " 'Diameter',\n",
+       " 'Velocity X',\n",
+       " 'Track Displacement',\n",
+       " 'Track Number of Branches',\n",
+       " 'Intensity Sum of Square Ch=3 Img=1',\n",
+       " 'Velocity Angle Z',\n",
+       " 'Track Intensity Min Ch=2 Img=1',\n",
+       " 'Track Number Of Generations',\n",
+       " 'Track Position Z Mean',\n",
+       " 'Overall',\n",
+       " 'Track Intensity Min Ch=1 Img=1',\n",
+       " 'Track Diameter Mean',\n",
+       " 'Intensity Max Ch=2 Img=1',\n",
+       " 'Displacement Delta Y',\n",
+       " 'Track Intensity Mean Ch=1 Img=1',\n",
+       " 'Average Distance To 3 Nearest Neighbours',\n",
+       " 'Displacement Z',\n",
+       " 'Track Position Z Start',\n",
+       " 'Acceleration Vector',\n",
+       " 'Velocity Angle Y',\n",
+       " 'Track Ar1 Z',\n",
+       " 'Track Position Y Mean',\n",
+       " 'Velocity',\n",
+       " 'Track Intensity Max Ch=2 Img=1',\n",
+       " 'Track Speed Variation',\n",
+       " 'Track Speed Max',\n",
+       " 'Displacement',\n",
+       " 'Track Intensity Min Ch=3 Img=1',\n",
+       " 'Velocity Y']"
+      ]
+     },
+     "execution_count": 24,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "list(test_stats_dict.keys())"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "724d808f",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "application/vnd.microsoft.datawrangler.viewer.v0+json": {
+       "columns": [
+        {
+         "name": "index",
+         "rawType": "int64",
+         "type": "integer"
+        },
+        {
+         "name": "Intensity Sum of Square",
+         "rawType": "object",
+         "type": "string"
+        },
+        {
+         "name": "Unit",
+         "rawType": "object",
+         "type": "string"
+        },
+        {
+         "name": "Category",
+         "rawType": "object",
+         "type": "string"
+        },
+        {
+         "name": "Channel",
+         "rawType": "object",
+         "type": "string"
+        },
+        {
+         "name": "Image",
+         "rawType": "object",
+         "type": "string"
+        },
+        {
+         "name": "Time",
+         "rawType": "object",
+         "type": "string"
+        },
+        {
+         "name": "TrackID",
+         "rawType": "object",
+         "type": "string"
+        },
+        {
+         "name": "ID",
+         "rawType": "object",
+         "type": "string"
+        },
+        {
+         "name": "",
+         "rawType": "object",
+         "type": "string"
+        }
+       ],
+       "ref": "58cedcb5-0cfe-4f83-a689-59f7e8bab984",
+       "rows": [
+        [
+         "0",
+         "80128.000",
+         "",
+         "Spot",
+         "2",
+         "Image 1",
+         "1",
+         "1000000039",
+         "39",
+         ""
+        ],
+        [
+         "1",
+         "64960.000",
+         "",
+         "Spot",
+         "2",
+         "Image 1",
+         "1",
+         "1000000042",
+         "42",
+         ""
+        ],
+        [
+         "2",
+         "38545.000",
+         "",
+         "Spot",
+         "2",
+         "Image 1",
+         "1",
+         "1000000060",
+         "60",
+         ""
+        ],
+        [
+         "3",
+         "56544.000",
+         "",
+         "Spot",
+         "2",
+         "Image 1",
+         "1",
+         "1000000065",
+         "65",
+         ""
+        ],
+        [
+         "4",
+         "46521.000",
+         "",
+         "Spot",
+         "2",
+         "Image 1",
+         "1",
+         "1000000073",
+         "73",
+         ""
+        ],
+        [
+         "5",
+         "49664.000",
+         "",
+         "Spot",
+         "2",
+         "Image 1",
+         "1",
+         "1000000083",
+         "83",
+         ""
+        ],
+        [
+         "6",
+         "94393.000",
+         "",
+         "Spot",
+         "2",
+         "Image 1",
+         "1",
+         "1000000085",
+         "85",
+         ""
+        ],
+        [
+         "7",
+         "140860.000",
+         "",
+         "Spot",
+         "2",
+         "Image 1",
+         "1",
+         "1000000091",
+         "91",
+         ""
+        ],
+        [
+         "8",
+         "107072.000",
+         "",
+         "Spot",
+         "2",
+         "Image 1",
+         "1",
+         "1000000110",
+         "110",
+         ""
+        ],
+        [
+         "9",
+         "54112.000",
+         "",
+         "Spot",
+         "2",
+         "Image 1",
+         "1",
+         "1000000114",
+         "114",
+         ""
+        ],
+        [
+         "10",
+         "110100.000",
+         "",
+         "Spot",
+         "2",
+         "Image 1",
+         "1",
+         "1000000120",
+         "120",
+         ""
+        ],
+        [
+         "11",
+         "69257.000",
+         "",
+         "Spot",
+         "2",
+         "Image 1",
+         "1",
+         "1000000135",
+         "135",
+         ""
+        ],
+        [
+         "12",
+         "171802.000",
+         "",
+         "Spot",
+         "2",
+         "Image 1",
+         "1",
+         "1000000151",
+         "151",
+         ""
+        ],
+        [
+         "13",
+         "51824.000",
+         "",
+         "Spot",
+         "2",
+         "Image 1",
+         "1",
+         "1000000161",
+         "161",
+         ""
+        ],
+        [
+         "14",
+         "42945.000",
+         "",
+         "Spot",
+         "2",
+         "Image 1",
+         "1",
+         "1000000170",
+         "170",
+         ""
+        ],
+        [
+         "15",
+         "97728.000",
+         "",
+         "Spot",
+         "2",
+         "Image 1",
+         "1",
+         "1000000179",
+         "179",
+         ""
+        ],
+        [
+         "16",
+         "64818.000",
+         "",
+         "Spot",
+         "2",
+         "Image 1",
+         "1",
+         "1000000188",
+         "188",
+         ""
+        ],
+        [
+         "17",
+         "72176.000",
+         "",
+         "Spot",
+         "2",
+         "Image 1",
+         "1",
+         "1000000189",
+         "189",
+         ""
+        ],
+        [
+         "18",
+         "99657.000",
+         "",
+         "Spot",
+         "2",
+         "Image 1",
+         "1",
+         "1000000190",
+         "190",
+         ""
+        ],
+        [
+         "19",
+         "129009.000",
+         "",
+         "Spot",
+         "2",
+         "Image 1",
+         "1",
+         "1000000193",
+         "193",
+         ""
+        ],
+        [
+         "20",
+         "102218.000",
+         "",
+         "Spot",
+         "2",
+         "Image 1",
+         "1",
+         "1000000195",
+         "195",
+         ""
+        ],
+        [
+         "21",
+         "42912.000",
+         "",
+         "Spot",
+         "2",
+         "Image 1",
+         "1",
+         "1000000199",
+         "199",
+         ""
+        ],
+        [
+         "22",
+         "101088.000",
+         "",
+         "Spot",
+         "2",
+         "Image 1",
+         "1",
+         "1000000200",
+         "200",
+         ""
+        ],
+        [
+         "23",
+         "114793.000",
+         "",
+         "Spot",
+         "2",
+         "Image 1",
+         "1",
+         "1000000239",
+         "239",
+         ""
+        ],
+        [
+         "24",
+         "92986.000",
+         "",
+         "Spot",
+         "2",
+         "Image 1",
+         "1",
+         "1000000265",
+         "265",
+         ""
+        ],
+        [
+         "25",
+         "57440.000",
+         "",
+         "Spot",
+         "2",
+         "Image 1",
+         "1",
+         "1000000317",
+         "317",
+         ""
+        ],
+        [
+         "26",
+         "41776.000",
+         "",
+         "Spot",
+         "2",
+         "Image 1",
+         "1",
+         "1000000391",
+         "391",
+         ""
+        ],
+        [
+         "27",
+         "57089.000",
+         "",
+         "Spot",
+         "2",
+         "Image 1",
+         "1",
+         "1000000399",
+         "399",
+         ""
+        ],
+        [
+         "28",
+         "45328.000",
+         "",
+         "Spot",
+         "2",
+         "Image 1",
+         "1",
+         "1000000410",
+         "410",
+         ""
+        ],
+        [
+         "29",
+         "31392.000",
+         "",
+         "Spot",
+         "2",
+         "Image 1",
+         "1",
+         "1000000496",
+         "496",
+         ""
+        ],
+        [
+         "30",
+         "69664.000",
+         "",
+         "Spot",
+         "2",
+         "Image 1",
+         "1",
+         "1000000557",
+         "557",
+         ""
+        ],
+        [
+         "31",
+         "60195.000",
+         "",
+         "Spot",
+         "2",
+         "Image 1",
+         "1",
+         "1000000562",
+         "562",
+         ""
+        ],
+        [
+         "32",
+         "101774.000",
+         "",
+         "Spot",
+         "2",
+         "Image 1",
+         "1",
+         "1000000569",
+         "569",
+         ""
+        ],
+        [
+         "33",
+         "91889.000",
+         "",
+         "Spot",
+         "2",
+         "Image 1",
+         "1",
+         "1000000570",
+         "570",
+         ""
+        ],
+        [
+         "34",
+         "69040.000",
+         "",
+         "Spot",
+         "2",
+         "Image 1",
+         "1",
+         "1000000573",
+         "573",
+         ""
+        ],
+        [
+         "35",
+         "101904.000",
+         "",
+         "Spot",
+         "2",
+         "Image 1",
+         "1",
+         "1000000581",
+         "581",
+         ""
+        ],
+        [
+         "36",
+         "80948.000",
+         "",
+         "Spot",
+         "2",
+         "Image 1",
+         "1",
+         "1000000587",
+         "587",
+         ""
+        ],
+        [
+         "37",
+         "89965.000",
+         "",
+         "Spot",
+         "2",
+         "Image 1",
+         "1",
+         "1000000588",
+         "588",
+         ""
+        ],
+        [
+         "38",
+         "70026.000",
+         "",
+         "Spot",
+         "2",
+         "Image 1",
+         "1",
+         "1000000590",
+         "590",
+         ""
+        ],
+        [
+         "39",
+         "70480.000",
+         "",
+         "Spot",
+         "2",
+         "Image 1",
+         "1",
+         "1000000611",
+         "611",
+         ""
+        ],
+        [
+         "40",
+         "66665.000",
+         "",
+         "Spot",
+         "2",
+         "Image 1",
+         "1",
+         "1000000620",
+         "620",
+         ""
+        ],
+        [
+         "41",
+         "66217.000",
+         "",
+         "Spot",
+         "2",
+         "Image 1",
+         "1",
+         "1000000745",
+         "745",
+         ""
+        ],
+        [
+         "42",
+         "39897.000",
+         "",
+         "Spot",
+         "2",
+         "Image 1",
+         "1",
+         "1000000751",
+         "751",
+         ""
+        ],
+        [
+         "43",
+         "11167.000",
+         "",
+         "Spot",
+         "2",
+         "Image 1",
+         "1",
+         "1000000759",
+         "759",
+         ""
+        ],
+        [
+         "44",
+         "38960.000",
+         "",
+         "Spot",
+         "2",
+         "Image 1",
+         "1",
+         "1000000766",
+         "766",
+         ""
+        ],
+        [
+         "45",
+         "28656.000",
+         "",
+         "Spot",
+         "2",
+         "Image 1",
+         "1",
+         "1000000947",
+         "947",
+         ""
+        ],
+        [
+         "46",
+         "70080.000",
+         "",
+         "Spot",
+         "2",
+         "Image 1",
+         "1",
+         "1000001002",
+         "1002",
+         ""
+        ],
+        [
+         "47",
+         "54448.000",
+         "",
+         "Spot",
+         "2",
+         "Image 1",
+         "1",
+         "1000001013",
+         "1013",
+         ""
+        ],
+        [
+         "48",
+         "52272.000",
+         "",
+         "Spot",
+         "2",
+         "Image 1",
+         "1",
+         "1000001033",
+         "1033",
+         ""
+        ],
+        [
+         "49",
+         "50119.000",
+         "",
+         "Spot",
+         "2",
+         "Image 1",
+         "1",
+         "1000001050",
+         "1050",
+         ""
+        ]
+       ],
+       "shape": {
+        "columns": 9,
+        "rows": 38980
+       }
+      },
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>Intensity Sum of Square</th>\n",
+       "      <th>Unit</th>\n",
+       "      <th>Category</th>\n",
+       "      <th>Channel</th>\n",
+       "      <th>Image</th>\n",
+       "      <th>Time</th>\n",
+       "      <th>TrackID</th>\n",
+       "      <th>ID</th>\n",
+       "      <th></th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>0</th>\n",
+       "      <td>80128.000</td>\n",
+       "      <td></td>\n",
+       "      <td>Spot</td>\n",
+       "      <td>2</td>\n",
+       "      <td>Image 1</td>\n",
+       "      <td>1</td>\n",
+       "      <td>1000000039</td>\n",
+       "      <td>39</td>\n",
+       "      <td></td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>1</th>\n",
+       "      <td>64960.000</td>\n",
+       "      <td></td>\n",
+       "      <td>Spot</td>\n",
+       "      <td>2</td>\n",
+       "      <td>Image 1</td>\n",
+       "      <td>1</td>\n",
+       "      <td>1000000042</td>\n",
+       "      <td>42</td>\n",
+       "      <td></td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>2</th>\n",
+       "      <td>38545.000</td>\n",
+       "      <td></td>\n",
+       "      <td>Spot</td>\n",
+       "      <td>2</td>\n",
+       "      <td>Image 1</td>\n",
+       "      <td>1</td>\n",
+       "      <td>1000000060</td>\n",
+       "      <td>60</td>\n",
+       "      <td></td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>3</th>\n",
+       "      <td>56544.000</td>\n",
+       "      <td></td>\n",
+       "      <td>Spot</td>\n",
+       "      <td>2</td>\n",
+       "      <td>Image 1</td>\n",
+       "      <td>1</td>\n",
+       "      <td>1000000065</td>\n",
+       "      <td>65</td>\n",
+       "      <td></td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>4</th>\n",
+       "      <td>46521.000</td>\n",
+       "      <td></td>\n",
+       "      <td>Spot</td>\n",
+       "      <td>2</td>\n",
+       "      <td>Image 1</td>\n",
+       "      <td>1</td>\n",
+       "      <td>1000000073</td>\n",
+       "      <td>73</td>\n",
+       "      <td></td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>...</th>\n",
+       "      <td>...</td>\n",
+       "      <td>...</td>\n",
+       "      <td>...</td>\n",
+       "      <td>...</td>\n",
+       "      <td>...</td>\n",
+       "      <td>...</td>\n",
+       "      <td>...</td>\n",
+       "      <td>...</td>\n",
+       "      <td>...</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>38975</th>\n",
+       "      <td>29738.000</td>\n",
+       "      <td></td>\n",
+       "      <td>Spot</td>\n",
+       "      <td>2</td>\n",
+       "      <td>Image 1</td>\n",
+       "      <td>55</td>\n",
+       "      <td>1000666870</td>\n",
+       "      <td>1294433</td>\n",
+       "      <td></td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>38976</th>\n",
+       "      <td>42695.000</td>\n",
+       "      <td></td>\n",
+       "      <td>Spot</td>\n",
+       "      <td>2</td>\n",
+       "      <td>Image 1</td>\n",
+       "      <td>59</td>\n",
+       "      <td>1000666870</td>\n",
+       "      <td>1294434</td>\n",
+       "      <td></td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>38977</th>\n",
+       "      <td>43121.000</td>\n",
+       "      <td></td>\n",
+       "      <td>Spot</td>\n",
+       "      <td>2</td>\n",
+       "      <td>Image 1</td>\n",
+       "      <td>61</td>\n",
+       "      <td>1000666870</td>\n",
+       "      <td>1294435</td>\n",
+       "      <td></td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>38978</th>\n",
+       "      <td>74319.000</td>\n",
+       "      <td></td>\n",
+       "      <td>Spot</td>\n",
+       "      <td>2</td>\n",
+       "      <td>Image 1</td>\n",
+       "      <td>51</td>\n",
+       "      <td>1000682257</td>\n",
+       "      <td>1294476</td>\n",
+       "      <td></td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>38979</th>\n",
+       "      <td>69462.000</td>\n",
+       "      <td></td>\n",
+       "      <td>Spot</td>\n",
+       "      <td>2</td>\n",
+       "      <td>Image 1</td>\n",
+       "      <td>53</td>\n",
+       "      <td>1000682257</td>\n",
+       "      <td>1294477</td>\n",
+       "      <td></td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "<p>38980 rows × 9 columns</p>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "      Intensity Sum of Square Unit Category Channel    Image Time     TrackID  \\\n",
+       "0                   80128.000          Spot       2  Image 1    1  1000000039   \n",
+       "1                   64960.000          Spot       2  Image 1    1  1000000042   \n",
+       "2                   38545.000          Spot       2  Image 1    1  1000000060   \n",
+       "3                   56544.000          Spot       2  Image 1    1  1000000065   \n",
+       "4                   46521.000          Spot       2  Image 1    1  1000000073   \n",
+       "...                       ...  ...      ...     ...      ...  ...         ...   \n",
+       "38975               29738.000          Spot       2  Image 1   55  1000666870   \n",
+       "38976               42695.000          Spot       2  Image 1   59  1000666870   \n",
+       "38977               43121.000          Spot       2  Image 1   61  1000666870   \n",
+       "38978               74319.000          Spot       2  Image 1   51  1000682257   \n",
+       "38979               69462.000          Spot       2  Image 1   53  1000682257   \n",
+       "\n",
+       "            ID     \n",
+       "0           39     \n",
+       "1           42     \n",
+       "2           60     \n",
+       "3           65     \n",
+       "4           73     \n",
+       "...        ... ..  \n",
+       "38975  1294433     \n",
+       "38976  1294434     \n",
+       "38977  1294435     \n",
+       "38978  1294476     \n",
+       "38979  1294477     \n",
+       "\n",
+       "[38980 rows x 9 columns]"
+      ]
+     },
+     "execution_count": 28,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "test_stats_dict[\"Intensity Sum of Square Ch=2 Img=1\"]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 31,
+   "id": "e40add1f",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "['Track Ar1 Mean',\n",
+       " 'Track Ar1 X',\n",
+       " 'Track Ar1 Y',\n",
+       " 'Track Ar1 Z',\n",
+       " 'Track Area Mean',\n",
+       " 'Track Diameter Mean',\n",
+       " 'Track Displacement Length',\n",
+       " 'Track Displacement X',\n",
+       " 'Track Displacement Y',\n",
+       " 'Track Displacement Z',\n",
+       " 'Track Duration',\n",
+       " 'Track Intensity Center Mean Ch=1 Img=1',\n",
+       " 'Track Intensity Center Mean Ch=2 Img=1',\n",
+       " 'Track Intensity Center Mean Ch=3 Img=1',\n",
+       " 'Track Intensity Max Ch=1 Img=1',\n",
+       " 'Track Intensity Max Ch=2 Img=1',\n",
+       " 'Track Intensity Max Ch=3 Img=1',\n",
+       " 'Track Intensity Mean Ch=1 Img=1',\n",
+       " 'Track Intensity Mean Ch=2 Img=1',\n",
+       " 'Track Intensity Mean Ch=3 Img=1',\n",
+       " 'Track Intensity Median Ch=1 Img=1',\n",
+       " 'Track Intensity Median Ch=2 Img=1',\n",
+       " 'Track Intensity Median Ch=3 Img=1',\n",
+       " 'Track Intensity Min Ch=1 Img=1',\n",
+       " 'Track Intensity Min Ch=2 Img=1',\n",
+       " 'Track Intensity Min Ch=3 Img=1',\n",
+       " 'Track Intensity StdDev Ch=1 Img=1',\n",
+       " 'Track Intensity StdDev Ch=2 Img=1',\n",
+       " 'Track Intensity StdDev Ch=3 Img=1',\n",
+       " 'Track Intensity Sum Ch=1 Img=1',\n",
+       " 'Track Intensity Sum Ch=2 Img=1',\n",
+       " 'Track Intensity Sum Ch=3 Img=1',\n",
+       " 'Track Length',\n",
+       " 'Track Number Of Generations',\n",
+       " 'Track Number of Branches',\n",
+       " 'Track Number of Fusions',\n",
+       " 'Track Number of Spots',\n",
+       " 'Track Position X Mean',\n",
+       " 'Track Position X Start',\n",
+       " 'Track Position Y Mean',\n",
+       " 'Track Position Y Start',\n",
+       " 'Track Position Z Mean',\n",
+       " 'Track Position Z Start',\n",
+       " 'Track Shortest Distance to Spots Min Spots=Spots Unnamed 1 spots.icsx_[ibrx_2025-08-05T15-14-37.820]',\n",
+       " 'Track Speed Max',\n",
+       " 'Track Speed Mean',\n",
+       " 'Track Speed Min',\n",
+       " 'Track Speed StdDev',\n",
+       " 'Track Speed Variation',\n",
+       " 'Track Straightness',\n",
+       " 'Track Volume Mean',\n",
+       " 'Track_ID']"
+      ]
+     },
+     "execution_count": 31,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "list(parser_df.columns)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 32,
+   "id": "836e6358",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "128"
+      ]
+     },
+     "execution_count": 32,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "len(test_stats_dict.keys())"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "0108111a",
+   "metadata": {},
+   "outputs": [
+    {
+     "ename": "TypeError",
+     "evalue": "unsupported operand type(s) for -: 'str' and 'list'",
+     "output_type": "error",
+     "traceback": [
+      "\u001b[31m---------------------------------------------------------------------------\u001b[39m",
+      "\u001b[31mTypeError\u001b[39m                                 Traceback (most recent call last)",
+      "\u001b[36mCell\u001b[39m\u001b[36m \u001b[39m\u001b[32mIn[99]\u001b[39m\u001b[32m, line 1\u001b[39m\n\u001b[32m----> \u001b[39m\u001b[32m1\u001b[39m \u001b[33;43m'\u001b[39;49m\u001b[33;43mTrack Intensity Sum Ch=2 Img=1\u001b[39;49m\u001b[33;43m'\u001b[39;49m\u001b[43m \u001b[49m\u001b[43m-\u001b[49m\u001b[43m \u001b[49m\u001b[43m[\u001b[49m\u001b[33;43m\"\u001b[39;49m\u001b[33;43mCh2\u001b[39;49m\u001b[33;43m\"\u001b[39;49m\u001b[43m]\u001b[49m\n",
+      "\u001b[31mTypeError\u001b[39m: unsupported operand type(s) for -: 'str' and 'list'"
+     ]
+    }
+   ],
+   "source": []
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "f2f271e7",
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "ImarisParser (3.12.4)",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.12.4"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/parser/dev_notebooks/dev_test_spot_track_object.ipynb
+++ b/parser/dev_notebooks/dev_test_spot_track_object.ipynb
@@ -1,0 +1,425 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "d2a66c29",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import sys\n",
+    "\n",
+    "sys.path.append(\"..\")\n",
+    "import os\n",
+    "import time\n",
+    "import glob\n",
+    "import numpy as np\n",
+    "import pandas as pd\n",
+    "from typing import List, Dict, Union, Tuple\n",
+    "from utils.data import load_yaml\n",
+    "from imaris.imaris import ImarisDataObject\n",
+    "from parsers.spot_track_parser import SpotTrackParserDistributed\n",
+    "from parsers.spot_track_object_parser import SpotTrackObjectParserDistributed\n",
+    "from tqdm.notebook import tqdm\n",
+    "\n",
+    "import csv"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "b691f834",
+   "metadata": {},
+   "source": [
+    "Get Stats From Parser"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "f7aca90d",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# test ims file path\n",
+    "test_ims_file = \"../../data/imaris_parser_test_files/Spots/KO Sec1 Roi1 3x3 80min.ims\""
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "2303f43a",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# parser = SpotTrackObjectParserDistributed(test_ims_file)\n",
+    "parser = SpotTrackParserDistributed(test_ims_file)\n",
+    "out = parser.inspect(1)\n",
+    "parser_df = out[\"final_df\"]\n",
+    "parser_stat_names = list(parser_df.columns)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "c0994b31",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "stats_names = out[\"stat_names_raw\"]\n",
+    "stats_names = list(set(stats_names[\"Name\"]))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "63c92391",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "stats_names"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "bd79d084",
+   "metadata": {},
+   "source": [
+    "Get Stats From Test Files"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "5c002c29",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# track stats folder\n",
+    "track_stats_dir = \"../../data/imaris_parser_test_files/Spots/KO Sec1 Roi1 3x3 80min-testtracks_Statistics\"\n",
+    "\n",
+    "# object stats folder\n",
+    "# track_stats_dir = (\n",
+    "#     \"../../data/imaris_parser_test_files/Spots/KO Sec1 Roi1 3x3 80min_Statistics\"\n",
+    "# )"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "7369d0c4",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "track_stats_files = glob.glob(os.path.join(track_stats_dir, \"*.csv\"))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "eaa17285",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def get_stats_df(path: str) -> Tuple[str, pd.DataFrame]:\n",
+    "    with open(path, newline=\"\", encoding=\"utf-8\") as f:\n",
+    "        reader = csv.reader(f)\n",
+    "        dataframe = []\n",
+    "        for row in reader:\n",
+    "            dataframe.append(row)\n",
+    "\n",
+    "    # get the stats name\n",
+    "    stat_name = dataframe[1][0]\n",
+    "\n",
+    "    # the first three rows from imaris export needs to be dropped\n",
+    "    dataframe = pd.DataFrame(dataframe[4:], columns=dataframe[3])\n",
+    "    # out = {stat_name: dataframe}\n",
+    "    return (stat_name, dataframe)\n",
+    "\n",
+    "\n",
+    "index = 6\n",
+    "items = get_stats_df(track_stats_files[index])"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "bfeac502",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# get all the stat from the test files into a dict\n",
+    "test_stats_dict = {}\n",
+    "for stat_test_path in tqdm(track_stats_files):\n",
+    "    items = get_stats_df(stat_test_path)\n",
+    "    if items[0] in test_stats_dict.keys():\n",
+    "        raise ValueError\n",
+    "    else:\n",
+    "        test_stats_dict[items[0]] = items[1]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "bcddbda0",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def get_original_stat_name(column_names, stats_names):\n",
+    "    for name in column_names:\n",
+    "        if name in stats_names:\n",
+    "            return name\n",
+    "    return ValueError(\"Column Names are Not in stats_name\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "12a6c4dd",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "f = test_stats_dict[\"Distance to Image Border XY Img=1\"]\n",
+    "valid_stat_name = get_original_stat_name(f.columns, stats_names)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "8fa3b839",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# loop over all the stat names we have in our parser\n",
+    "drop_columns = [\n",
+    "    \"Unit\",\n",
+    "    \"Category\",\n",
+    "    \"Time\",\n",
+    "    \"Channel\",\n",
+    "    \"Image\",\n",
+    "    \"\",\n",
+    "    \"Collection\",\n",
+    "    \"Spots\",\n",
+    "]\n",
+    "for stat_name in tqdm(parser_stat_names):\n",
+    "\n",
+    "    if stat_name not in [\"Track_ID\", \"Time\", \"Time Index\", \"Object_ID\"]:\n",
+    "\n",
+    "        # get the stats df that we are using for validation\n",
+    "        gt_stats_df = test_stats_dict[stat_name]\n",
+    "\n",
+    "        # we need to filter out irrelevant columns such as Unit, Category, Time, etc\n",
+    "        # we should only keep the statistics name, track id and object id\n",
+    "        # process gt\n",
+    "        for column in drop_columns:\n",
+    "            if column in gt_stats_df.columns:\n",
+    "                gt_stats_df = gt_stats_df.drop(columns=column)\n",
+    "\n",
+    "        # get the valid stats name from the gt_stats_file\n",
+    "        valid_stat_name = get_original_stat_name(gt_stats_df.columns, stats_names)\n",
+    "\n",
+    "        # keep the track and object ids if present\n",
+    "        pred_filtered = []\n",
+    "        if \"TrackID\" in gt_stats_df.columns and \"ID\" in gt_stats_df.columns:\n",
+    "            track_id_series = parser_df[\"Track_ID\"]\n",
+    "            track_id_series.name = \"TrackID\"\n",
+    "            object_id_series = parser_df[\"Object_ID\"]\n",
+    "            object_id_series.name = \"ID\"\n",
+    "            pred_filtered.append(track_id_series)\n",
+    "            pred_filtered.append(object_id_series)\n",
+    "        elif \"ID\" in gt_stats_df.columns:\n",
+    "            # Here Track_ID in ours = ID\n",
+    "            track_id_series = parser_df[\"Track_ID\"]\n",
+    "            track_id_series.name = \"ID\"\n",
+    "            pred_filtered.append(track_id_series)\n",
+    "\n",
+    "        # get the stats for the current stats_name\n",
+    "        pred_filtered.append(parser_df[stat_name])\n",
+    "\n",
+    "        # if the stat name is not the same as valid_stat_name\n",
+    "        # we need to modify it\n",
+    "        stat_name_new = None\n",
+    "        if stat_name != valid_stat_name:\n",
+    "            stat_name_new = stat_name[: len(valid_stat_name)]\n",
+    "\n",
+    "        # stack\n",
+    "        pred_filtered_df = pd.concat(pred_filtered, axis=1)\n",
+    "\n",
+    "        # change decimal format\n",
+    "        pred_filtered_df[stat_name] = (\n",
+    "            pred_filtered_df[stat_name].astype(float).map(lambda x: f\"{x:.3f}\")\n",
+    "        )\n",
+    "\n",
+    "        # rename the new columns\n",
+    "        if stat_name_new:\n",
+    "            pred_filtered_df = pred_filtered_df.rename(\n",
+    "                columns={stat_name: stat_name_new}\n",
+    "            )\n",
+    "\n",
+    "        # convert whole df to string\n",
+    "        pred_filtered_df = pred_filtered_df.astype(str)\n",
+    "\n",
+    "        # reorder columns\n",
+    "        pred_filtered_df = pred_filtered_df[gt_stats_df.columns]\n",
+    "\n",
+    "        # reset index\n",
+    "        pred_filtered_df = pred_filtered_df.reset_index(drop=\"index\")\n",
+    "\n",
+    "        # compare the two\n",
+    "        match = gt_stats_df.equals(pred_filtered_df)\n",
+    "        if not match:\n",
+    "            print(f\"Error: Stats for Name {stat_name} Does Not Match\")\n",
+    "        else:\n",
+    "            print(f\"Pass: Stats for {stat_name}\")\n",
+    "        # break"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "c3b10fe5",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "pred_filtered_df"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "d7822380",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "stat_name"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "0108111a",
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "f2f271e7",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# loop over all the stat names we have in our parser\n",
+    "drop_columns = [\n",
+    "    \"Unit\",\n",
+    "    \"Category\",\n",
+    "    \"Time\",\n",
+    "    \"Channel\",\n",
+    "    \"Image\",\n",
+    "    \"\",\n",
+    "    \"Collection\",\n",
+    "    \"Spots\",\n",
+    "]\n",
+    "for stat_name in tqdm(parser_stat_names):\n",
+    "\n",
+    "    if stat_name not in [\"Track_ID\", \"Time\", \"Time Index\", \"Object_ID\"]:\n",
+    "\n",
+    "        # get the stats df that we are using for validation\n",
+    "        gt_stats_df = test_stats_dict[stat_name]\n",
+    "\n",
+    "        # we need to filter out irrelevant columns such as Unit, Category, Time, etc\n",
+    "        # we should only keep the statistics name, track id and object id\n",
+    "        # process gt\n",
+    "        for column in drop_columns:\n",
+    "            if column in gt_stats_df.columns:\n",
+    "                gt_stats_df = gt_stats_df.drop(columns=column)\n",
+    "\n",
+    "        # get the valid stats name from the gt_stats_file\n",
+    "        valid_stat_name = get_original_stat_name(gt_stats_df.columns, stats_names)\n",
+    "\n",
+    "        # keep the track and object ids if present\n",
+    "        pred_filtered = []\n",
+    "        if \"TrackID\" in gt_stats_df.columns and \"ID\" in gt_stats_df.columns:\n",
+    "            track_id_series = parser_df[\"Track_ID\"]\n",
+    "            track_id_series.name = \"TrackID\"\n",
+    "            object_id_series = parser_df[\"Object_ID\"]\n",
+    "            object_id_series.name = \"ID\"\n",
+    "            pred_filtered.append(track_id_series)\n",
+    "            pred_filtered.append(object_id_series)\n",
+    "        elif \"ID\" in gt_stats_df.columns:\n",
+    "            # Here Track_ID in ours = ID\n",
+    "            track_id_series = parser_df[\"Track_ID\"]\n",
+    "            track_id_series.name = \"ID\"\n",
+    "            pred_filtered.append(track_id_series)\n",
+    "\n",
+    "        # get the stats for the current stats_name\n",
+    "        pred_filtered.append(parser_df[stat_name])\n",
+    "\n",
+    "        # if the stat name is not the same as valid_stat_name\n",
+    "        # we need to modify it\n",
+    "        stat_name_new = None\n",
+    "        if stat_name != valid_stat_name:\n",
+    "            stat_name_new = stat_name[: len(valid_stat_name)]\n",
+    "\n",
+    "        # stack\n",
+    "        pred_filtered_df = pd.concat(pred_filtered, axis=1)\n",
+    "\n",
+    "        # change decimal format\n",
+    "        pred_filtered_df[stat_name] = (\n",
+    "            pred_filtered_df[stat_name].astype(float).map(lambda x: f\"{x:.3f}\")\n",
+    "        )\n",
+    "\n",
+    "        # rename the new columns\n",
+    "        if stat_name_new:\n",
+    "            pred_filtered_df = pred_filtered_df.rename(\n",
+    "                columns={stat_name: stat_name_new}\n",
+    "            )\n",
+    "\n",
+    "        # convert whole df to string\n",
+    "        pred_filtered_df = pred_filtered_df.astype(str)\n",
+    "\n",
+    "        # reorder columns\n",
+    "        pred_filtered_df = pred_filtered_df[gt_stats_df.columns]\n",
+    "\n",
+    "        # reset index\n",
+    "        pred_filtered_df = pred_filtered_df.reset_index(drop=\"index\")\n",
+    "\n",
+    "        # compare the two\n",
+    "        match = gt_stats_df.equals(pred_filtered_df)\n",
+    "        if not match:\n",
+    "            print(f\"Error: Stats for Name {stat_name} Does Not Match\")\n",
+    "        else:\n",
+    "            print(f\"Pass: Stats for {stat_name}\")\n",
+    "        # break"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "ef2baf1d",
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "ImarisParser (3.12.4)",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.12.4"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/parser/parsers/parser_base.py
+++ b/parser/parsers/parser_base.py
@@ -99,7 +99,7 @@ class Parser(ABC):
 
         stats_names["Name"] = stats_names.apply(
             lambda row: (
-                f"{row['Name']} Channel_{int(row['Channel_Level'])}"
+                f"{row['Name']} Ch={int(row['Channel_Level'])}"
                 if pd.notna(row["Channel_Level"])
                 else row["Name"]
             ),
@@ -152,6 +152,48 @@ class Parser(ABC):
 
         return stats_names
 
+    def _update_spot_info_fast(
+        self,
+        stats_names: pd.DataFrame,
+        factor: pd.DataFrame,
+    ) -> pd.DataFrame:
+        """
+        Updates the channel information for the relavent rows
+        based on th ID_FactorList information in stats_names
+
+        Args:
+            stats_names (pd.DataFrame): _description_
+            factor (pd.DataFrame): _description_
+
+        Returns:
+            pd.DataFrame: _description_
+        """
+
+        # Build mapping from ID_List -> Level for Surfaces
+        surface_map = (
+            factor.loc[factor["Name"] == "Spots", ["ID_List", "Level"]]
+            .set_index("ID_List")["Level"]
+            .to_dict()
+        )
+
+        # Map surface levels to stats_names
+        stats_names["Spots_Level"] = stats_names["ID_FactorList"].map(surface_map)
+
+        # Update Name column: append surface level if exists
+        stats_names["Name"] = stats_names.apply(
+            lambda row: (
+                f"{row['Name']} Spots={row['Spots_Level']}"
+                if pd.notna(row["Spots_Level"])
+                else row["Name"]
+            ),
+            axis=1,
+        )
+
+        # Drop the helper column
+        stats_names = stats_names.drop(columns="Spots_Level")
+
+        return stats_names
+
     def _update_image_level_info_fast(
         self,
         stats_names: pd.DataFrame,
@@ -182,7 +224,7 @@ class Parser(ABC):
         # Update Name column: append surface level if exists
         stats_names["Name"] = stats_names.apply(
             lambda row: (
-                f"{row['Name']} {row['Image_Level']}"
+                f"{row['Name']} Img={int(row['Image_Level'].split(" ")[-1])}"
                 if pd.notna(row["Image_Level"])
                 else row["Name"]
             ),

--- a/parser/parsers/spot_track_object_parser.py
+++ b/parser/parsers/spot_track_object_parser.py
@@ -232,23 +232,26 @@ class SpotTrackObjectParserDistributed(Parser):
         spot_name = self.spot_names[spot_id]
         storage["spot_name"] = spot_name
         stat_names = self.stats_names.get(spot_id)
-        storage["stat_names_raw"] = stat_names
+        storage["stat_names_raw"] = deepcopy(stat_names)
         stat_values = self.stats_values.get(spot_id)
-        storage["stat_values_raw"] = stat_values
+        storage["stat_values_raw"] = deepcopy(stat_values)
         object_id = self.object_ids.get(spot_id)
         storage["object_id"] = object_id
         factor = self.factors.get(spot_id)
         storage["factor"] = factor
 
         # update channel names
-        start = time.perf_counter()
-        stat_names = self._update_channel_info_fast(
-            stats_names=deepcopy(stat_names),
-            factor=factor,
-        )
-        print(stat_names.shape, object_id.shape)
-        print(f"time: {time.perf_counter() - start}")
-        storage["stat_names_channel_info_fast"] = deepcopy(stat_names)
+        # update spot name
+        stat_names = self._update_spot_info_fast(stat_names, factor)
+        storage["stat_names_channel_info"] = stat_names
+
+        # update channel
+        stat_names = self._update_channel_info_fast(stat_names, factor)
+        storage["stat_names_channel_info"] = stat_names
+
+        # update img info
+        stat_names = self._update_image_level_info_fast(stat_names, factor)
+        storage["stat_names_img_info"] = stat_names
 
         # filter stats values by object ids (ie: ignore info related to trackids)
         stat_values = self._filter_stats(
@@ -269,9 +272,9 @@ class SpotTrackObjectParserDistributed(Parser):
         storage["available_stats_names"] = available_stats_names
 
         # organize stats value
-        start = time.perf_counter()
+        # start = time.perf_counter()
         organized_stats = self._organize_stats_fast(stat_values)
-        print(f"time organize stats: {time.perf_counter() - start}")
+        # print(f"time organize stats: {time.perf_counter() - start}")
         storage["organized_stats_fast"] = organized_stats
 
         # generate csv
@@ -280,9 +283,9 @@ class SpotTrackObjectParserDistributed(Parser):
 
         # add track id information for each object
         if self.track_ids[spot_id] is not None:
-            start = time.perf_counter()
+            # start = time.perf_counter()
             stats_df = self._update_track_id_info(spot_id, stats_df)
-            print(f"time update track info: {time.perf_counter() - start}")
+            # print(f"time update track info: {time.perf_counter() - start}")
             storage["final_df"] = stats_df
         else:
             print(

--- a/parser/parsers/spot_track_parser.py
+++ b/parser/parsers/spot_track_parser.py
@@ -254,19 +254,25 @@ class SpotTrackParserDistributed(Parser):
         spot_name = self.spot_names[spot_id]
         storage["spot_name"] = spot_name
         stat_names = self.stats_names.get(spot_id)
-        storage["stat_names_raw"] = stat_names
+        storage["stat_names_raw"] = deepcopy(stat_names)
         stat_values = self.stats_values.get(spot_id)
-        storage["stat_values_raw"] = stat_values
+        storage["stat_values_raw"] = deepcopy(stat_values)
         track_id = self.track_ids.get(spot_id)
         storage["track_id"] = track_id
         factor = self.factors.get(spot_id)
         storage["factor"] = factor
 
-        # update channel
-        stat_names = self._update_channel_info_fast(
-            stats_names=stat_names, factor=factor
-        )
+        # update spot name
+        stat_names = self._update_spot_info_fast(stat_names, factor)
         storage["stat_names_channel_info"] = stat_names
+
+        # update channel
+        stat_names = self._update_channel_info_fast(stat_names, factor)
+        storage["stat_names_channel_info"] = stat_names
+
+        # update img info
+        stat_names = self._update_image_level_info_fast(stat_names, factor)
+        storage["stat_names_img_info"] = stat_names
 
         # filter stats values by object ids (ie: ignore info related to trackids)
         stat_values = self._filter_stats(

--- a/test/test_spot_track_object_parser.py
+++ b/test/test_spot_track_object_parser.py
@@ -1,0 +1,173 @@
+import sys
+
+sys.path.append("../parser")
+import os
+import csv
+import glob
+import pandas as pd
+from typing import Tuple
+from parsers.spot_track_object_parser import SpotTrackObjectParserDistributed
+from tqdm import tqdm
+
+
+################################################################################################
+################################################################################################
+def get_stats_df(path: str) -> Tuple[str, pd.DataFrame]:
+    with open(path, newline="", encoding="utf-8") as f:
+        reader = csv.reader(f)
+        dataframe = []
+        for row in reader:
+            dataframe.append(row)
+
+    # get the stats name
+    stat_name = dataframe[1][0]
+
+    # the first three rows from imaris export needs to be dropped
+    dataframe = pd.DataFrame(dataframe[4:], columns=dataframe[3])
+    # out = {stat_name: dataframe}
+    return (stat_name, dataframe)
+
+
+################################################################################################
+################################################################################################
+def get_original_stat_name(column_names, stats_names):
+    for name in column_names:
+        if name in stats_names:
+            return name
+    return ValueError("Column Names are Not in stats_name")
+
+
+################################################################################################
+################################################################################################
+if __name__ == "__main__":
+
+    # test ims file path
+    test_ims_file = "/home/shehan/Documents/projects/nih/projects/ImarisParser/data/imaris_parser_test_files/Spots/KO Sec1 Roi1 3x3 80min.ims"
+
+    # parser
+    print("[info] Loading Imaris File")
+    parser = SpotTrackObjectParserDistributed(test_ims_file)
+
+    print("[info] Calculating Statistics")
+    out = parser.inspect(1)
+    parser_df = out["final_df"]
+    parser_stat_names = list(parser_df.columns)
+    stats_names = out["stat_names_raw"]
+    stats_names = list(set(stats_names["Name"]))
+
+    # track stats files
+    print("[info] Gathering Ground Truth Files")
+    track_stats_dir = "/home/shehan/Documents/projects/nih/projects/ImarisParser/data/imaris_parser_test_files/Spots/KO Sec1 Roi1 3x3 80min-testtracks_Statistics"
+    track_stats_files = glob.glob(os.path.join(track_stats_dir, "*.csv"))
+
+    # get all the stat from the test files into a dict
+    print("[info] Extracting Ground Truth Data")
+    test_stats_dict = {}
+    for stat_test_path in tqdm(track_stats_files):
+        items = get_stats_df(stat_test_path)
+        if items[0] in test_stats_dict.keys():
+            raise ValueError
+        else:
+            test_stats_dict[items[0]] = items[1]
+
+    # loop over all the stat names we have in our parser
+    print("[info] Verifying Parser Output with Ground Truth ...")
+    drop_columns = [
+        "Unit",
+        "Category",
+        "Time",
+        "Channel",
+        "Image",
+        "",
+        "Collection",
+        "Spots",
+    ]
+    passed_count = 0
+    total = 0
+    omitted_stats = []
+    for stat_name in tqdm(parser_stat_names):
+        try:
+            if stat_name not in ["Track_ID", "Time", "Time Index", "Object_ID"]:
+
+                # get the stats df that we are using for validation
+                gt_stats_df = test_stats_dict[stat_name]
+
+                # we need to filter out irrelevant columns such as Unit, Category, Time, etc
+                # we should only keep the statistics name, track id and object id
+                # process gt
+                for column in drop_columns:
+                    if column in gt_stats_df.columns:
+                        gt_stats_df = gt_stats_df.drop(columns=column)
+
+                # get the valid stats name from the gt_stats_file
+                valid_stat_name = get_original_stat_name(
+                    gt_stats_df.columns, stats_names
+                )
+
+                # keep the track and object ids if present
+                pred_filtered = []
+                if "TrackID" in gt_stats_df.columns and "ID" in gt_stats_df.columns:
+                    track_id_series = parser_df["Track_ID"]
+                    track_id_series.name = "TrackID"
+                    object_id_series = parser_df["Object_ID"]
+                    object_id_series.name = "ID"
+                    pred_filtered.append(track_id_series)
+                    pred_filtered.append(object_id_series)
+                elif "ID" in gt_stats_df.columns:
+                    # Here Track_ID in ours = ID
+                    track_id_series = parser_df["Track_ID"]
+                    track_id_series.name = "ID"
+                    pred_filtered.append(track_id_series)
+
+                # get the stats for the current stats_name
+                pred_filtered.append(parser_df[stat_name])
+
+                # if the stat name is not the same as valid_stat_name
+                # we need to modify it
+                stat_name_new = None
+                if stat_name != valid_stat_name:
+                    stat_name_new = stat_name[: len(valid_stat_name)]
+
+                # stack
+                pred_filtered_df = pd.concat(pred_filtered, axis=1)
+
+                # change decimal format
+                pred_filtered_df[stat_name] = (
+                    pred_filtered_df[stat_name].astype(float).map(lambda x: f"{x:.3f}")
+                )
+
+                # rename the new columns
+                if stat_name_new:
+                    pred_filtered_df = pred_filtered_df.rename(
+                        columns={stat_name: stat_name_new}
+                    )
+
+                # convert whole df to string
+                pred_filtered_df = pred_filtered_df.astype(str)
+
+                # reorder columns
+                pred_filtered_df = pred_filtered_df[gt_stats_df.columns]
+
+                # reset index
+                pred_filtered_df = pred_filtered_df.reset_index(drop="index")
+
+                # compare the two
+                match = gt_stats_df.equals(pred_filtered_df)
+                if not match:
+                    # print(f"Error: Stats for Name {stat_name} Does Not Match")
+                    pass
+                else:
+                    # print(f"Pass: Stats for {stat_name}")
+                    passed_count += 1
+
+                total += 1
+
+        except Exception as e:
+            print(f"[error] - Test raised exception {e} at stat name {stat_name}")
+
+    if passed_count != total:
+        print(f"Test FAILED only passed {passed_count}/{total}")
+    else:
+        print(f"All statistics values match -- Test PASSED {passed_count}/{total}")
+################################################################################################
+################################################################################################

--- a/test/test_spot_track_parser.py
+++ b/test/test_spot_track_parser.py
@@ -1,0 +1,174 @@
+import sys
+
+sys.path.append("../parser")
+import os
+import csv
+import glob
+import pandas as pd
+from typing import Tuple
+from parsers.spot_track_parser import SpotTrackParserDistributed
+from tqdm import tqdm
+
+
+################################################################################################
+################################################################################################
+def get_stats_df(path: str) -> Tuple[str, pd.DataFrame]:
+    with open(path, newline="", encoding="utf-8") as f:
+        reader = csv.reader(f)
+        dataframe = []
+        for row in reader:
+            dataframe.append(row)
+
+    # get the stats name
+    stat_name = dataframe[1][0]
+
+    # the first three rows from imaris export needs to be dropped
+    dataframe = pd.DataFrame(dataframe[4:], columns=dataframe[3])
+    # out = {stat_name: dataframe}
+    return (stat_name, dataframe)
+
+
+################################################################################################
+################################################################################################
+def get_original_stat_name(column_names, stats_names):
+    for name in column_names:
+        if name in stats_names:
+            return name
+    return ValueError("Column Names are Not in stats_name")
+
+
+################################################################################################
+################################################################################################
+if __name__ == "__main__":
+
+    # test ims file path
+    test_ims_file = "/home/shehan/Documents/projects/nih/projects/ImarisParser/data/imaris_parser_test_files/Spots/KO Sec1 Roi1 3x3 80min.ims"
+
+    # parser
+    print("[info] Loading Imaris File")
+    parser = SpotTrackParserDistributed(test_ims_file)
+
+    print("[info] Calculating Statistics")
+    out = parser.inspect(1)
+    parser_df = out["final_df"]
+    parser_stat_names = list(parser_df.columns)
+    stats_names = out["stat_names_raw"]
+    stats_names = list(set(stats_names["Name"]))
+
+    # track stats files
+    print("[info] Gathering Ground Truth Files")
+    track_stats_dir = "/home/shehan/Documents/projects/nih/projects/ImarisParser/data/imaris_parser_test_files/Spots/KO Sec1 Roi1 3x3 80min-testtracks_Statistics"
+    track_stats_files = glob.glob(os.path.join(track_stats_dir, "*.csv"))
+
+    # get all the stat from the test files into a dict
+    print("[info] Extracting Ground Truth Data")
+    test_stats_dict = {}
+    for stat_test_path in tqdm(track_stats_files):
+        items = get_stats_df(stat_test_path)
+        if items[0] in test_stats_dict.keys():
+            raise ValueError
+        else:
+            test_stats_dict[items[0]] = items[1]
+
+    # loop over all the stat names we have in our parser
+    print("[info] Verifying Parser Output with Ground Truth ...")
+    drop_columns = [
+        "Unit",
+        "Category",
+        "Time",
+        "Channel",
+        "Image",
+        "",
+        "Collection",
+        "Spots",
+    ]
+    passed_count = 0
+    total = 0
+    omitted_stats = []
+    for stat_name in tqdm(parser_stat_names):
+        try:
+            if stat_name not in ["Track_ID", "Time", "Time Index", "Object_ID"]:
+
+                # get the stats df that we are using for validation
+                gt_stats_df = test_stats_dict[stat_name]
+
+                # we need to filter out irrelevant columns such as Unit, Category, Time, etc
+                # we should only keep the statistics name, track id and object id
+                # process gt
+                for column in drop_columns:
+                    if column in gt_stats_df.columns:
+                        gt_stats_df = gt_stats_df.drop(columns=column)
+
+                # get the valid stats name from the gt_stats_file
+                valid_stat_name = get_original_stat_name(
+                    gt_stats_df.columns, stats_names
+                )
+
+                # keep the track and object ids if present
+                pred_filtered = []
+                if "TrackID" in gt_stats_df.columns and "ID" in gt_stats_df.columns:
+                    track_id_series = parser_df["Track_ID"]
+                    track_id_series.name = "TrackID"
+                    object_id_series = parser_df["Object_ID"]
+                    object_id_series.name = "ID"
+                    pred_filtered.append(track_id_series)
+                    pred_filtered.append(object_id_series)
+                elif "ID" in gt_stats_df.columns:
+                    # Here Track_ID in ours = ID
+                    track_id_series = parser_df["Track_ID"]
+                    track_id_series.name = "ID"
+                    pred_filtered.append(track_id_series)
+
+                # get the stats for the current stats_name
+                pred_filtered.append(parser_df[stat_name])
+
+                # if the stat name is not the same as valid_stat_name
+                # we need to modify it
+                stat_name_new = None
+                if stat_name != valid_stat_name:
+                    stat_name_new = stat_name[: len(valid_stat_name)]
+
+                # stack
+                pred_filtered_df = pd.concat(pred_filtered, axis=1)
+
+                # change decimal format
+                pred_filtered_df[stat_name] = (
+                    pred_filtered_df[stat_name].astype(float).map(lambda x: f"{x:.3f}")
+                )
+
+                # rename the new columns
+                if stat_name_new:
+                    pred_filtered_df = pred_filtered_df.rename(
+                        columns={stat_name: stat_name_new}
+                    )
+
+                # convert whole df to string
+                pred_filtered_df = pred_filtered_df.astype(str)
+
+                # reorder columns
+                pred_filtered_df = pred_filtered_df[gt_stats_df.columns]
+
+                # reset index
+                pred_filtered_df = pred_filtered_df.reset_index(drop="index")
+
+                # compare the two
+                match = gt_stats_df.equals(pred_filtered_df)
+                if not match:
+                    # print(f"Error: Stats for Name {stat_name} Does Not Match")
+                    pass
+                else:
+                    # print(f"Pass: Stats for {stat_name}")
+                    passed_count += 1
+
+                total += 1
+
+        except Exception as e:
+            print(f"[error] - Test raised exception {e} at stat name {stat_name}")
+
+    if passed_count != total:
+        print(f"Test FAILED only passed {passed_count}/{total}")
+    else:
+        print(f"All statistics values match -- Test PASSED {passed_count}/{total}")
+
+################################################################################################
+################################################################################################


### PR DESCRIPTION
added support for spot parsers that includes the spot_track_parser and spot_track_object_parser.
other parsers have not been tested but the underlying logic is the same for all parsers. 
tests for other parsers will be added as I get those files. 

So far the the tests for the spot parsers passed. 